### PR TITLE
internal/ci: deploy tip.cuelan.org via repository_dispatch

### DIFF
--- a/.github/workflows/tip_triggers.yml
+++ b/.github/workflows/tip_triggers.yml
@@ -13,7 +13,7 @@ jobs:
         shell: bash
     if: ${{github.repository == 'cue-lang/cue'}}
     steps:
-      - name: Rebuild tip.cuelang.org
-        run: curl -f -s -X POST -d {} https://api.netlify.com/build_hooks/${{ secrets.CUELANGORGTIPREBUILDHOOK }}
+      - name: Trigger tip.cuelang.org deploy
+        run: 'curl -f -s -H "Content-Type: application/json" -u cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} --request POST --data-binary "{\"event_type\":\"Rebuild tip against ${GITHUB_SHA}\",\"client_payload\":{\"type\":\"rebuild_tip\"}}" https://api.github.com/repos/cue-lang/cuelang.org/dispatches'
       - name: Trigger unity build
         run: 'curl -f -s -H "Content-Type: application/json" -u cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} --request POST --data-binary "{\"event_type\":\"Check against ${GITHUB_SHA}\",\"client_payload\":{\"type\":\"unity\",\"payload\":{\"versions\":\"\\\"commit:${GITHUB_SHA}\\\"\"}}}" https://api.github.com/repos/cue-unity/unity/dispatches'

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -28,9 +28,15 @@ tip_triggers: _base.#bashWorkflow & {
 		"runs-on": _#linuxMachine
 		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
 		steps: [
-			{
-				name: "Rebuild tip.cuelang.org"
-				run:  "\(_base.#curl) -X POST -d {} https://api.netlify.com/build_hooks/${{ secrets.CUELANGORGTIPREBUILDHOOK }}"
+			_base.#repositoryDispatch & {
+				name:           "Trigger tip.cuelang.org deploy"
+				#repositoryURL: "https://github.com/cue-lang/cuelang.org"
+				#arg: {
+					event_type: "Rebuild tip against ${GITHUB_SHA}"
+					client_payload: {
+						type: "rebuild_tip"
+					}
+				}
 			},
 			_base.#repositoryDispatch & {
 				name:           "Trigger unity build"


### PR DESCRIPTION
Now that tip.cuelang.org is its own site, deployed from a workflow in
the cue-lang/cuelang.org repo (as opposed to a job that runs on
Netlify), we need to be able to trigger that workflow from other places.
Specifically, we need to be able to trigger a deploy when we get a new
commit at the tip of this repo.

Therefore we update the tip_triggers workflow in this repository to
trigger the update_tip workflow in cuelang.org via repository_dispatch.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I7a2b63a9212aa071b3bf16a1a952813fa8bf9c46
