### PR TITLE
cmd/cue: don't panic in vet if a schema uses conditionals

### DIFF
--- a/cmd/cue/cmd/common.go
+++ b/cmd/cue/cmd/common.go
@@ -624,7 +624,7 @@ func parseArgs(cmd *Command, args []string, cfg *config) (p *buildPlan, err erro
 				[]*build.Instance{schema},
 				true)[0]
 
-			if inst.err != nil {
+			if err := inst.err; err != nil {
 				return nil, err
 			}
 			p.instance = inst
@@ -634,7 +634,11 @@ func parseArgs(cmd *Command, args []string, cfg *config) (p *buildPlan, err erro
 					cue.InferBuiltins(true),
 					cue.Scope(inst.Value()))
 				if err := v.Err(); err != nil {
-					return nil, v.Validate()
+					// Validate may give us a more detailed error.
+					if err2 := v.Validate(); err2 != nil {
+						err = err2
+					}
+					return nil, err
 				}
 				p.encConfig.Schema = v
 			}

--- a/cmd/cue/cmd/testdata/script/issue2207.txtar
+++ b/cmd/cue/cmd/testdata/script/issue2207.txtar
@@ -1,0 +1,12 @@
+! exec cue vet data.yaml schema.cue -d '#schema'
+stderr 'non-concrete value int in operand to >'
+
+-- data.yaml --
+a: 200
+-- schema.cue --
+#schema: {
+	a: int
+	if a > 100 {
+		b: true
+	}
+}


### PR DESCRIPTION
In the added test case, parseArgs would return `(nil, nil)`,
as `v.Err()` gave a non-nil error but `v.Validate()` gave nil.

Users of parseArgs, such as the vet command,
expect parseArgs to return a non-nil `*buildPlan` if there is no error,
which is a common way to use funcs in Go returning `(*T, error)`.
This discrepancy would cause a nil dereference panic:

	> ! exec cue vet data.yaml schema.cue -d '#schema'
	[stderr]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
		panic: runtime error: invalid memory address or nil pointer dereference
	[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xb7a3fa]

	goroutine 1 [running]:
	cuelang.org/go/cmd/cue/cmd.recoverError(0xc0004bb9d8)
		/home/mvdan/src/cue/cue/cmd/cue/cmd/root.go:232 +0x7b
	panic({0xc22680, 0x12d8740})
		/home/mvdan/tip/src/runtime/panic.go:884 +0x213
	cuelang.org/go/cmd/cue/cmd.doVet(0xc0002d91d0, {0xc000322340, 0x2, 0x4})
		/home/mvdan/src/cue/cue/cmd/cue/cmd/vet.go:98 +0xba
	[...]

Ensure that parseArgs never returns two nils.
There were two scenarios where this could happen; fix both.
The other scenario does not appear to cause any real bugs yet,
as we appear to ignore all errors per the TODO above.

TODO: it's not clear to me whether the command should fail,
or whether it should fail with a better error message.

Fixes #2207.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I2a006b6c0b3ef39cefe2c66ebd5d154aac2dedb8
