### PR TITLE
cmd/cue: don't panic in vet if a schema has incomplete errors

### DIFF
--- a/cmd/cue/cmd/testdata/script/issue2207.txtar
+++ b/cmd/cue/cmd/testdata/script/issue2207.txtar
@@ -1,0 +1,23 @@
+exec cue vet data.yaml schema.cue
+
+exec cue vet data2.yaml schema2.cue
+
+exec cue vet data.yaml schema2.cue -d x
+
+-- data.yaml --
+a: 200
+-- schema.cue --
+a: int
+if a > 100 {
+	b: true
+}
+-- data2.yaml --
+x:
+  a: 200
+-- schema2.cue --
+x: {
+	a: int
+	if a > 100 {
+		b: true
+	}
+}

--- a/cue/types.go
+++ b/cue/types.go
@@ -2210,6 +2210,9 @@ func (o *options) updateOptions(opts []Option) {
 // Validate reports any errors, recursively. The returned error may represent
 // more than one error, retrievable with errors.Errors, if more than one
 // exists.
+//
+// Note that by default not all errors are reported, unless options like
+// Concrete are used.
 func (v Value) Validate(opts ...Option) error {
 	o := options{}
 	o.updateOptions(opts)


### PR DESCRIPTION
In the added test case, parseArgs would return `(nil, nil)`,
as `v.Err()` gave a non-nil error but `v.Validate()` gave nil.

Users of parseArgs, such as the vet command,
expect parseArgs to return a non-nil `*buildPlan` if there is no error,
which is a common way to use funcs in Go returning `(*T, error)`.
This discrepancy would cause a nil dereference panic:

	> ! exec cue vet data.yaml schema.cue -d '#schema'
	[stderr]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
		panic: runtime error: invalid memory address or nil pointer dereference
	[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xb7a3fa]

	goroutine 1 [running]:
	cuelang.org/go/cmd/cue/cmd.recoverError(0xc0004bb9d8)
		/home/mvdan/src/cue/cue/cmd/cue/cmd/root.go:232 +0x7b
	panic({0xc22680, 0x12d8740})
		/home/mvdan/tip/src/runtime/panic.go:884 +0x213
	cuelang.org/go/cmd/cue/cmd.doVet(0xc0002d91d0, {0xc000322340, 0x2, 0x4})
		/home/mvdan/src/cue/cue/cmd/cue/cmd/vet.go:98 +0xba
	[...]

Ensure that parseArgs never returns two nils.
There were two scenarios where this could happen; fix both.
The other scenario does not appear to cause any real bugs yet,
as we appear to ignore all errors per the TODO above.

Another issue was that error checking for schema was too strict,
as it would count incomplete errors. Incomplete errors could
still be resolved when unifying with the code to be validated.

Fixes #2207.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I2a006b6c0b3ef39cefe2c66ebd5d154aac2dedb8
