### PR TITLE
internal/ci: make github CLI shell invocations safer

### DIFF
--- a/.github/workflows/trybot_dispatch.yml
+++ b/.github/workflows/trybot_dispatch.yml
@@ -31,10 +31,10 @@ jobs:
           git config user.name cueckoo
           git config user.email cueckoo@gmail.com
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
-          git fetch https://review.gerrithub.io/a/cue-lang/cue ${{ github.event.client_payload.payload.ref }}
+          git fetch https://review.gerrithub.io/a/cue-lang/cue "${{ github.event.client_payload.payload.ref }}"
           git checkout -b trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }} FETCH_HEAD
           git remote add origin https://github.com/cue-lang/cue-trybot
-          git fetch origin ${{ github.event.client_payload.payload.branch }}
+          git fetch origin "${{ github.event.client_payload.payload.branch }}"
           git push origin trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}
           echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
-          gh pr -R https://github.com/cue-lang/cue-trybot create -B ${{ github.event.client_payload.payload.branch }} -f
+          gh pr --repo=https://github.com/cue-lang/cue-trybot create --base="${{ github.event.client_payload.payload.branch }}" --fill

--- a/internal/ci/gerrithub/gerrithub.cue
+++ b/internal/ci/gerrithub/gerrithub.cue
@@ -83,13 +83,13 @@ _#linuxMachine: "ubuntu-20.04"
 						git config user.name \(#botGitHubUser)
 						git config user.email \(#botGitHubUserEmail)
 						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(#botGitHubUser):${{ secrets.\(#botGitHubUserTokenSecretsKey) }} | base64)"
-						git fetch \(#gerritHubRepository) ${{ github.event.client_payload.payload.ref }}
+						git fetch \(#gerritHubRepository) "${{ github.event.client_payload.payload.ref }}"
 						git checkout -b \(_#branchNameExpression) FETCH_HEAD
 						git remote add origin \(#trybotRepositoryURL)
-						git fetch origin ${{ github.event.client_payload.payload.branch }}
+						git fetch origin "${{ github.event.client_payload.payload.branch }}"
 						git push origin \(_#branchNameExpression)
 						echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
-						gh pr -R \(#trybotRepositoryURL) create -B ${{ github.event.client_payload.payload.branch }} -f
+						gh pr --repo=\(#trybotRepositoryURL) create --base="${{ github.event.client_payload.payload.branch }}" --fill
 						"""
 				},
 			]


### PR DESCRIPTION
We used to run the equivalent of:

	gh pr -R CONST_URL create -B $branch -f

However, if $branch was unset, due to the cueckoo tool being too old,
we would run:

	gh pr -R CONST_URL create -B -f

which failed, as it is interpreted just like:

	gh pr -R CONST_URL create -B=-f

To avoid this problem, use quotes for github actions variables used in
git and gh commands, to ensure they don't expand to a missing word.

While here, use long flag names, as I had to look up `gh pr create -h`.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I1eaf66650ea00fe57e77925fd6aa2a2222e13398
