### PR TITLE
internal/core/adt: evaluate expressions directly

### DIFF
--- a/cue/testdata/eval/let.txtar
+++ b/cue/testdata/eval/let.txtar
@@ -38,6 +38,18 @@ ignoreErrorInLet: {
 	let X = 1 & 2
 	disjunction: *X | 3
 }
+-- issue2166.cue --
+letWithDynamicInComprehension: {
+	_i: {
+		a: "d"
+		b: "e"
+	}
+	
+	for k, v in _i {
+		let T = v
+		(T): "1"
+	}
+}
 -- issue2063.cue --
 import (
 	"encoding/yaml"
@@ -67,14 +79,14 @@ keepDescending: t2: {
 
 -- out/eval/stats --
 Leaks:  6
-Freed:  48
-Reused: 39
+Freed:  57
+Reused: 48
 Allocs: 15
-Retain: 21
+Retain: 24
 
-Unifications: 52
-Conjuncts:    74
-Disjuncts:    59
+Unifications: 61
+Conjuncts:    91
+Disjuncts:    69
 -- out/eval --
 (struct){
   let A#1 = (int){ 9 }
@@ -148,6 +160,21 @@ Disjuncts:    59
       }
     }
   }
+  letWithDynamicInComprehension: (struct){
+    let T#1B = (_|_){
+      // [eval] letWithDynamicInComprehension.T: conflicting values "e" and "d":
+      //     ./issue2166.cue:3:6
+      //     ./issue2166.cue:4:6
+      //     ./issue2166.cue:7:2
+      //     ./issue2166.cue:8:11
+    }
+    _i: (struct){
+      a: (string){ "d" }
+      b: (string){ "e" }
+    }
+    d: (string){ "1" }
+    e: (string){ "1" }
+  }
 }
 -- out/compile --
 --- in.cue
@@ -216,6 +243,19 @@ Disjuncts:    59
           Y: 〈import;strings〉.Join([], "")
         }
       }
+    }
+  }
+}
+--- issue2166.cue
+{
+  letWithDynamicInComprehension: {
+    _i: {
+      a: "d"
+      b: "e"
+    }
+    for k, v in 〈0;_i〉 {
+      let T#1B = 〈1;v〉
+      〈0;let T#1B〉: "1"
     }
   }
 }

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -934,6 +934,11 @@ func (x *LetReference) resolve(ctx *OpContext, state VertexStatus) *Vertex {
 	key := cacheKey{expr, arc}
 	v, ok := e.cache[key]
 	if !ok {
+		// Link in the right environment to ensure comprehension context is not
+		// lost. Use a Vertex to piggyback on cycle processing.
+		c.Env = e
+		c.x = expr
+
 		if e.cache == nil {
 			e.cache = map[cacheKey]Value{}
 		}


### PR DESCRIPTION
When comprehensions are evaluated, each yielded result is
associated with an Environment that corresponds with the
destination Vertex, rather than  an intermediate Vertex
corresponding to the comprehension Value.

At the same time, before this change, conflicting let references
were resolved by creating a new Vertex keeping the original values.
For comprehensions, however, this could lead to an  incorrect wiring
of the Environments, causing a reference to anyway be linked to the
conflicting let.

This change rewrites a LetReference Vertex result to evaluate
its expression value directly, with the appropriate Environment.
This could theoretically lead to less optimal position reporting.
In practice the position reporting seems sufficient, though, and
this change does not affect any of the previous tests.

Fixes #2166

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Ifacb05d23cf887f0625ebe103c6ed60aafa755c9
