### PR TITLE
git internal/core/adt: don't add errors to "void" arcs

### DIFF
--- a/cue/testdata/comprehensions/issue1732.txtar
+++ b/cue/testdata/comprehensions/issue1732.txtar
@@ -180,10 +180,6 @@ Disjuncts:    126
     #SomeConfig: (_|_){
       // [incomplete] common.#SomeConfig: incomplete bool: bool:
       //     ./in.cue:41:12
-      foo: (_|_){
-        // [incomplete] common.#SomeConfig: incomplete bool: bool:
-        //     ./in.cue:41:12
-      }
       enabled: (bool){ bool }
     }
   }
@@ -203,10 +199,6 @@ Disjuncts:    126
     auth0: (_|_){
       // [incomplete] #Config.auth0: incomplete bool: bool:
       //     ./in.cue:41:12
-      foo: (_|_){
-        // [incomplete] #Config.auth0: incomplete bool: bool:
-        //     ./in.cue:41:12
-      }
       enabled: (bool){ bool }
     }
     charts: (#struct){
@@ -245,10 +237,6 @@ Disjuncts:    126
     auth0: (_|_){
       // [incomplete] #Flux.auth0: incomplete bool: bool:
       //     ./in.cue:41:12
-      foo: (_|_){
-        // [incomplete] #Flux.auth0: incomplete bool: bool:
-        //     ./in.cue:41:12
-      }
       enabled: (bool){ bool }
     }
     charts: (#struct){

--- a/cue/testdata/comprehensions/pushdown.txtar
+++ b/cue/testdata/comprehensions/pushdown.txtar
@@ -564,6 +564,46 @@ allArcsSuccess: p2: {
 	}
 }
 
+-- issue2208.cue --
+voidErrorIncomplete: {
+	#Schema: [string]: {
+		required: bool
+		if !required {
+		}
+	}
+
+	root: #Schema
+	root: {
+		if false {
+			child: required: false
+		}
+	}
+}
+
+// TODO: should these always be errors, or always for cue vet?
+// voidErrorFatal: pattern: {
+// 	#Schema: [string]: {
+// 		if "str" + 3 {
+// 		}
+// 	}
+//
+// 	root: #Schema
+// 	root: {
+// 		if false {
+// 			child: required: false
+// 		}
+// 	}
+// }
+//
+// voidErrorFatal: field: {
+// 	root: {
+// 		if false {
+// 			child: 2 + "str"
+// 		}
+// 	}
+// }
+
+
 -- issue1759.cue --
 // Tests derived from Unity.
 unity: success1: {
@@ -703,14 +743,14 @@ unifyDynamicReflectSuccess: {
 
 -- out/eval/stats --
 Leaks:  16
-Freed:  387
-Reused: 380
+Freed:  392
+Reused: 385
 Allocs: 23
-Retain: 68
+Retain: 69
 
-Unifications: 389
-Conjuncts:    636
-Disjuncts:    433
+Unifications: 394
+Conjuncts:    644
+Disjuncts:    439
 -- out/eval --
 Errors:
 embed.fail1.p: field not allowed:
@@ -781,10 +821,6 @@ Result:
     a: (_|_){
       // [cycle] fail.a: cycle with field a.b:
       //     ./in.cue:30:6
-      b: (_|_){
-        // [cycle] fail.a: cycle with field a.b:
-        //     ./in.cue:30:6
-      }
     }
   }
   embed: (_|_){
@@ -910,10 +946,6 @@ Result:
       #a: (_|_){
         // [incomplete] provideIncompleteSuccess.t1.#a: incomplete bool: bool:
         //     ./in.cue:172:7
-        c: (_|_){
-          // [incomplete] provideIncompleteSuccess.t1.#a: incomplete bool: bool:
-          //     ./in.cue:172:7
-        }
         b: (bool){ bool }
       }
       x: (#struct){
@@ -1030,11 +1062,6 @@ Result:
         // [incomplete] closedCheck.success1.#D: non-concrete value string in operand to !=:
         //     ./in.cue:267:6
         //     ./in.cue:266:6
-        e: (_|_){
-          // [incomplete] closedCheck.success1.#D: non-concrete value string in operand to !=:
-          //     ./in.cue:267:6
-          //     ./in.cue:266:6
-        }
         d: (string){ string }
       }
     }
@@ -1083,11 +1110,6 @@ Result:
   }
   voidEliminationSuccess: (struct){
     t1: (struct){
-      a: (_|_){
-        // [incomplete] voidEliminationSuccess.t1.a: operand b of '!' not concrete (was bool):
-        //     ./in.cue:326:7
-        b: (bool){ bool }
-      }
     }
     t2: (struct){
       components: (struct){
@@ -1376,6 +1398,12 @@ Result:
           out: (string){ "test" }
         }
       }
+    }
+  }
+  voidErrorIncomplete: (struct){
+    #Schema: (#struct){
+    }
+    root: (#struct){
     }
   }
   unifyDynamicReflectSuccess: (struct){
@@ -2221,6 +2249,25 @@ Result:
           〈2;k〉: {
             out: "test"
           }
+        }
+      }
+    }
+  }
+}
+--- issue2208.cue
+{
+  voidErrorIncomplete: {
+    #Schema: {
+      [string]: {
+        required: bool
+        if !〈0;required〉 {}
+      }
+    }
+    root: 〈0;#Schema〉
+    root: {
+      if false {
+        child: {
+          required: false
         }
       }
     }

--- a/cue/testdata/cycle/023_reentrance.txtar
+++ b/cue/testdata/cycle/023_reentrance.txtar
@@ -104,14 +104,6 @@ Result:
     // fib: non-concrete value int in operand to <:
     //     ./in.cue:10:5
     //     ./in.cue:5:5
-    out: (_|_){
-      // [incomplete] fib: non-concrete value int in operand to >=:
-      //     ./in.cue:7:5
-      //     ./in.cue:5:5
-      // fib: non-concrete value int in operand to <:
-      //     ./in.cue:10:5
-      //     ./in.cue:5:5
-    }
     n: (int){ int }
   }
   fib1: (int){ 1 }

--- a/cue/testdata/cycle/compbottom2.txtar
+++ b/cue/testdata/cycle/compbottom2.txtar
@@ -279,10 +279,6 @@ Disjuncts:    163
       a: (_|_){
         // [cycle] self.fail.a: cycle with field a.b:
         //     ./in.cue:6:7
-        b: (_|_){
-          // [cycle] self.fail.a: cycle with field a.b:
-          //     ./in.cue:6:7
-        }
       }
     }
     isConcreteFail: (struct){
@@ -492,10 +488,6 @@ Disjuncts:    163
       #E: (_|_){
         // [cycle] nestedChain.cycleFail: cycle with field #E.y:
         //     ./nestedchain.cue:7:6
-        x: (_|_){
-          // [cycle] nestedChain.cycleFail: cycle with field #E.y:
-          //     ./nestedchain.cue:7:6
-        }
       }
     }
     brokenCycleSuccess: (struct){
@@ -511,10 +503,6 @@ Disjuncts:    163
         // [cycle] nestedChain.doubleAddfail: cycle with field #E.y:
         //     ./nestedchain.cue:28:6
         y: (bool){ true }
-        x: (_|_){
-          // [cycle] nestedChain.doubleAddfail: cycle with field #E.y:
-          //     ./nestedchain.cue:28:6
-        }
       }
     }
     trippleSuccess: (struct){

--- a/cue/testdata/cycle/compbottomnofinal.txtar
+++ b/cue/testdata/cycle/compbottomnofinal.txtar
@@ -365,7 +365,7 @@ Retain: 129
 
 Unifications: 111
 Conjuncts:    194
-Disjuncts:    127
+Disjuncts:    130
 -- out/eval --
 (struct){
   minimal: (struct){
@@ -445,10 +445,6 @@ Disjuncts:    127
       #X: (_|_){
         // [cycle] medium.p3.#X: cycle with field Y.port:
         //     ./in.cue:114:7
-        port: (_|_){
-          // [cycle] medium.p3.#X: cycle with field Y.port:
-          //     ./in.cue:114:7
-        }
       }
     }
     p4: (struct){
@@ -459,10 +455,6 @@ Disjuncts:    127
       #X: (_|_){
         // [cycle] medium.p4.#X: cycle with field Y.port:
         //     ./in.cue:134:7
-        port: (_|_){
-          // [cycle] medium.p4.#X: cycle with field Y.port:
-          //     ./in.cue:134:7
-        }
       }
       #Y: (_|_){
         // [cycle] medium.p4.#X: cycle with field Y.port:
@@ -547,14 +539,9 @@ Disjuncts:    127
     }
     p3: (struct){
       X: (string){ "user@mod.test" }
-      #X: (_|_){
-        // [cycle] large.p3.Y: undefined field: port:
-        //     ./in.cue:308:10
+      #X: (#struct){
         userinfo: (string){ "user@" }
-        port: (_|_){
-          // [cycle] large.p3.Y: undefined field: port:
-          //     ./in.cue:308:10
-        }
+        port: (string){ "" }
         host: (string){ "mod.test" }
       }
       Y: (struct){
@@ -574,14 +561,9 @@ Disjuncts:    127
     }
     p4: (struct){
       X: (string){ "user@mod.test" }
-      #X: (_|_){
-        // [cycle] large.p4.Y: undefined field: port:
-        //     ./in.cue:351:10
+      #X: (#struct){
         userinfo: (string){ "user@" }
-        port: (_|_){
-          // [cycle] large.p4.Y: undefined field: port:
-          //     ./in.cue:351:10
-        }
+        port: (string){ "" }
         host: (string){ "mod.test" }
       }
       #Y: (#struct){

--- a/cue/testdata/fulleval/042_cross-dependent_comprehension.txtar
+++ b/cue/testdata/fulleval/042_cross-dependent_comprehension.txtar
@@ -53,10 +53,6 @@ Disjuncts:    11
   #a: (_|_){
     // [incomplete] #a: incomplete bool: bool:
     //     ./in.cue:5:5
-    c: (_|_){
-      // [incomplete] #a: incomplete bool: bool:
-      //     ./in.cue:5:5
-    }
     b: (bool){ bool }
   }
   x: (#struct){

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -496,6 +496,9 @@ func (n *nodeContext) postDisjunct(state VertexStatus) {
 
 	switch err := n.getErr(); {
 	case err != nil:
+		if err.Code < IncompleteError && n.node.arcType == arcVoid {
+			n.node.arcType = arcMember
+		}
 		n.node.BaseValue = err
 		n.errs = nil
 
@@ -619,15 +622,7 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 		if c.err == nil {
 			continue
 		}
-		// TODO: Current flow doesn't handle adding errors to parents well.
-		//       Fix this, though, as this is a more appropriate location to
-		//       report the error.
-		// if c.node != nil {
-		// 	c.node.AddErr(n.ctx, c.err)
-		// 	continue
-		// }
 		err = CombineErrors(nil, err, c.err)
-		n.node.arcType = arcMember
 
 		// TODO: use this code once possible.
 		//
@@ -655,16 +650,8 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 		if c.err == nil {
 			continue
 		}
-		// TODO: Current flow doesn't handle adding errors to parents well.
-		//       Fix this, though, as this is a more appropriate location to
-		//       report the error.
-		// if c.node != nil {
-		// 	c.node.AddErr(n.ctx, c.err)
-		// 	continue
-		// }
+
 		err = CombineErrors(nil, err, c.err)
-		// n.node.arcType &^= arcVoid
-		n.node.arcType = arcMember
 
 		// TODO: use this code once possible.
 		//
@@ -694,6 +681,9 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 	if err == nil {
 		// safeguard.
 		err = incompleteSentinel
+	}
+	if err.Code < IncompleteError {
+		n.node.arcType = arcMember
 	}
 	return err
 }

--- a/internal/core/export/testdata/main/let.txtar
+++ b/internal/core/export/testdata/main/let.txtar
@@ -316,9 +316,6 @@ y: Y & Y_1
 [unresolvedDisjunction #TypePrimitive Args required]
 [unresolvedDisjunction #TypePrimitive "*"]
 [unresolvedDisjunction #TypeBool]
-[unresolvedDisjunction #TypeBool default]
-- `default` sets the default value.
-
 [unresolvedDisjunction #TypeBool _args]
 [unresolvedDisjunction #TypeBool _args required]
 [unresolvedDisjunction #TypeBool Args]


### PR DESCRIPTION
The new comprehension algorithm pushes computation of
comprehensions down into fixed fields. Such fields (arcs) are
referred to as "void", as they won't exist until a comprehension
results in a value added to them.
Errors that occur in void arcs, such as incomplete errors, should
therefore not automatically result in an error.

This changes removes the automatic promotion of void arcs to
full arcs upon error.

Note that this remove various duplicate errors.
In compbottomnofinal this removal looks a bit aggressive,
but it is still okay: as long as an error is reported
at least once it is fine.

A question remains whether certain permanent errors should
always be serviced, either during all evaluation or a more strict
vet mode only.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: I5280cd921dc3e76993d58954cdc2cf7bf9947b39
