### PR TITLE
internal/core/debug: change notation for "multi" lets

### DIFF
--- a/cue/testdata/builtins/closed.txtar
+++ b/cue/testdata/builtins/closed.txtar
@@ -118,7 +118,7 @@ Result:
             a: (#struct){
               b: (bool){ true }
             }
-            let X#1 = 〈0;a〉 // multi
+            let X#1multi = 〈0;a〉
             uint: (#struct){
               a: (#struct){
                 b: (bool){ true }
@@ -128,7 +128,7 @@ Result:
             a: (#struct){
               b: (bool){ true }
             }
-            let X#1 = 〈0;a〉 // multi
+            let X#1multi = 〈0;a〉
             string: (#struct){
               a: (#struct){
                 b: (bool){ true }
@@ -139,7 +139,7 @@ Result:
             a: (#struct){
               b: (bool){ true }
             }
-            let X#1 = 〈0;a〉 // multi
+            let X#1multi = 〈0;a〉
             uint: (#struct){
               a: (#struct){
                 b: (bool){ true }
@@ -149,7 +149,7 @@ Result:
             a: (#struct){
               b: (bool){ true }
             }
-            let X#1 = 〈0;a〉 // multi
+            let X#1multi = 〈0;a〉
             string: (#struct){
               a: (#struct){
                 b: (bool){ true }

--- a/cue/testdata/eval/issue2146.txtar
+++ b/cue/testdata/eval/issue2146.txtar
@@ -92,10 +92,10 @@ Disjuncts:    197
       x: (int){ 3 }
     }
     b: (#struct){
-      let list#1 = [
+      let list#1multi = [
         〈1;x〉,
         〈1;y〉,
-      ] // multi
+      ]
       all: (#list){
         0: (int){ 3 }
       }
@@ -142,10 +142,10 @@ Disjuncts:    197
       y: (int){ 2 }
     }
     b: (#struct){
-      let list#2 = [
+      let list#2multi = [
         〈1;x〉,
         〈1;y〉,
-      ] // multi
+      ]
       all: (#list){
         0: (int){ 3 }
         1: (int){ 2 }

--- a/cue/testdata/eval/letjoin.txtar
+++ b/cue/testdata/eval/letjoin.txtar
@@ -87,10 +87,10 @@ Disjuncts:    69
       }
     }
     xy: (struct){
-      let X#1 = {
+      let X#1multi = {
         b: 〈2;a〉
         c: 1
-      } // multi
+      }
       v: (int){ 1 }
     }
   }
@@ -141,10 +141,10 @@ Disjuncts:    69
         r: (int){ 2 }
       }
       y: (struct){
-        let X#2 = {
+        let X#2multi = {
           b: 〈2;a〉
           c: 1
-        } // multi
+        }
         v: (int){ 1 }
       }
     }

--- a/internal/core/debug/compact.go
+++ b/internal/core/debug/compact.go
@@ -53,10 +53,12 @@ func (w *compactPrinter) node(n adt.Node) {
 				if a.Label.IsLet() {
 					w.string("let ")
 					w.label(a.Label)
+					if a.MultiLet {
+						w.string("m")
+					}
 					w.string("=")
 					if c := a.Conjuncts[0]; a.MultiLet {
 						w.node(c.Expr())
-						w.string(" // multi")
 						continue
 					}
 					w.node(a)

--- a/internal/core/debug/debug.go
+++ b/internal/core/debug/debug.go
@@ -225,10 +225,12 @@ func (w *printer) node(n adt.Node) {
 			if a.Label.IsLet() {
 				w.string("let ")
 				w.label(a.Label)
+				if a.MultiLet {
+					w.string("multi")
+				}
 				w.string(" = ")
 				if c := a.Conjuncts[0]; a.MultiLet {
 					w.node(c.Expr())
-					w.string(" // multi")
 					continue
 				}
 				w.node(a)


### PR DESCRIPTION
This is a bit more "embedable" and works a bit
better with upcoming changes where multi mode is
already computed in the compiler and thus can be
annotated within an expression.

Issue #2218

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: I66488e8d79cea440443901f4326969c66283ebfc
