### PR TITLE
github: bring the bug report template up to date

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!--
 Please answer these questions before submitting your issue. Thanks!
-For questions please use one of our forums: https://cuelang.slack.com/
+To ask questions, see https://github.com/cue-lang/cue#contact.
 -->
 
 ### What version of CUE are you using (`cue version`)?
@@ -18,10 +18,6 @@ For questions please use one of our forums: https://cuelang.slack.com/
 $ cue version
 
 </pre>
-
-<!--
-If you built from source, specify what git tag or commit was used.
--->
 
 ### Does this issue reproduce with the latest release?
 


### PR DESCRIPTION
Slack is no longer the only place to ask questions;
we've been primarily relying on GitHub Discussions for a while now.
We could link to both, but it could get lengthy as a plaintext comment,
and it might go out of date again. Link to the README instead.

We no longer need to ask CUE users to pull the git tag or commit
manually when building from source; `cue version` now fetches the
stamped VCS information as well, since June 2022.
It's still possible for users to manually build older versions from
source, but it seems very unlikely that they would raise bugs about
those versions at this point.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: Icc8dc1cdce5da93e02b4efcc1b80b778a74ad73b
