### PR TITLE
cue/load: minor tweaks

### DIFF
--- a/cue/load/config.go
+++ b/cue/load/config.go
@@ -15,6 +15,7 @@
 package load
 
 import (
+	"fmt"
 	"io"
 	"os"
 	pathpkg "path"
@@ -35,7 +36,7 @@ import (
 const (
 	cueSuffix  = ".cue"
 	modDir     = "cue.mod"
-	configFile = "module.cue"
+	moduleFile = "module.cue"
 	pkgDir     = "pkg"
 )
 
@@ -303,7 +304,12 @@ func (c *Config) newInstance(pos token.Pos, p importPath) *build.Instance {
 	return i
 }
 
+// newRelInstance returns a build instance from the given
+// relative import path.
 func (c *Config) newRelInstance(pos token.Pos, path, pkgName string) *build.Instance {
+	if !isLocalImport(path) {
+		panic(fmt.Errorf("non-relative import path %q passed to newRelInstance", path))
+	}
 	fs := c.fileSystem
 
 	var err errors.Error
@@ -316,17 +322,9 @@ func (c *Config) newRelInstance(pos token.Pos, path, pkgName string) *build.Inst
 	p.Root = c.ModuleRoot
 	p.Module = c.Module
 
-	if isLocalImport(path) {
-		if c.Dir == "" {
-			err = errors.Append(err, errors.Newf(pos, "cwd unknown"))
-		}
-		dir = filepath.Join(c.Dir, filepath.FromSlash(path))
-	}
+	dir = filepath.Join(c.Dir, filepath.FromSlash(path))
 
-	if path == "" {
-		err = errors.Append(err, errors.Newf(pos,
-			"import %q: invalid import path", path))
-	} else if path != cleanImport(path) {
+	if path != cleanImport(path) {
 		err = errors.Append(err, c.loader.errPkgf(nil,
 			"non-canonical import path: %q should be %q", path, pathpkg.Clean(path)))
 	}
@@ -480,7 +478,8 @@ func (c *Config) absDirFromImportPath(pos token.Pos, p importPath) (absDir, name
 
 // Complete updates the configuration information. After calling complete,
 // the following invariants hold:
-//   - c.ModuleRoot != ""
+//   - c.Dir is an absolute path.
+//   - c.ModuleRoot is an absolute path
 //   - c.Module is set to the module import prefix if there is a cue.mod file
 //     with the module property.
 //   - c.loader != nil
@@ -517,60 +516,16 @@ func (c Config) complete() (cfg *Config, err error) {
 		if root := c.findRoot(c.Dir); root != "" {
 			c.ModuleRoot = root
 		}
+	} else if !filepath.IsAbs(c.ModuleRoot) {
+		c.ModuleRoot = filepath.Join(c.Dir, c.ModuleRoot)
 	}
-
+	if err := c.completeModule(); err != nil {
+		return nil, err
+	}
 	c.loader = &loader{
 		cfg:       &c,
 		buildTags: make(map[string]bool),
 	}
-
-	// TODO: also make this work if run from outside the module?
-	switch {
-	case true:
-		mod := filepath.Join(c.ModuleRoot, modDir)
-		info, cerr := c.fileSystem.stat(mod)
-		if cerr != nil {
-			break
-		}
-		if info.IsDir() {
-			mod = filepath.Join(mod, configFile)
-		}
-		f, cerr := c.fileSystem.openFile(mod)
-		if cerr != nil {
-			break
-		}
-
-		// TODO: move to full build again
-		file, err := parser.ParseFile("load", f)
-		if err != nil {
-			return nil, errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
-		}
-
-		r := runtime.New()
-		v, err := compile.Files(nil, r, "_", file)
-		if err != nil {
-			return nil, errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
-		}
-		ctx := eval.NewContext(r, v)
-		v.Finalize(ctx)
-		prefix := v.Lookup(ctx.StringLabel("module"))
-		if prefix != nil {
-			name := ctx.StringValue(prefix.Value())
-			if err := ctx.Err(); err != nil {
-				return &c, err.Err
-			}
-			pos := token.NoPos
-			src := prefix.Value().Source()
-			if src != nil {
-				pos = src.Pos()
-			}
-			if c.Module != "" && c.Module != name {
-				return &c, errors.Newf(pos, "inconsistent modules: got %q, want %q", name, c.Module)
-			}
-			c.Module = name
-		}
-	}
-
 	c.loadFunc = c.loader.loadFunc()
 
 	if c.Context == nil {
@@ -579,8 +534,62 @@ func (c Config) complete() (cfg *Config, err error) {
 			build.ParseFile(c.loader.cfg.ParseFile),
 		)
 	}
-
 	return &c, nil
+}
+
+// completeModule fills out c.Module if it's empty or checks it for
+// consistency with the module file otherwise.
+func (c *Config) completeModule() error {
+	// TODO: also make this work if run from outside the module?
+	mod := filepath.Join(c.ModuleRoot, modDir)
+	info, cerr := c.fileSystem.stat(mod)
+	if cerr != nil {
+		return nil
+	}
+	// TODO remove support for legacy non-directory module.cue file
+	// by returning an error if info.IsDir is false.
+	if info.IsDir() {
+		mod = filepath.Join(mod, moduleFile)
+	}
+	f, cerr := c.fileSystem.openFile(mod)
+	if cerr != nil {
+		return nil
+	}
+	defer f.Close()
+
+	// TODO: move to full build again
+	file, err := parser.ParseFile("load", f)
+	if err != nil {
+		return errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
+	}
+
+	r := runtime.New()
+	v, err := compile.Files(nil, r, "_", file)
+	if err != nil {
+		return errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
+	}
+	ctx := eval.NewContext(r, v)
+	v.Finalize(ctx)
+	prefix := v.Lookup(ctx.StringLabel("module"))
+	if prefix == nil {
+		return nil
+	}
+	name := ctx.StringValue(prefix.Value())
+	if err := ctx.Err(); err != nil {
+		return err.Err
+	}
+	if c.Module == "" {
+		c.Module = name
+		return nil
+	}
+	if c.Module == name {
+		return nil
+	}
+	pos := token.NoPos
+	if src := prefix.Value().Source(); src != nil {
+		pos = src.Pos()
+	}
+	return errors.Newf(pos, "inconsistent modules: got %q, want %q", name, c.Module)
 }
 
 func (c Config) isRoot(dir string) bool {
@@ -590,14 +599,11 @@ func (c Config) isRoot(dir string) bool {
 	return err == nil
 }
 
-// findRoot returns the module root or "" if none was found.
-func (c Config) findRoot(dir string) string {
+// findRoot returns the module root that's ancestor
+// of the given absolute directory path, or "" if none was found.
+func (c Config) findRoot(absDir string) string {
 	fs := &c.fileSystem
 
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return ""
-	}
 	abs := absDir
 	for {
 		if c.isRoot(abs) {

--- a/cue/load/import.go
+++ b/cue/load/import.go
@@ -52,7 +52,7 @@ const (
 )
 
 // importPkg returns details about the CUE package named by the import path,
-// interpreting local import paths relative to the srcDir directory.
+// interpreting local import paths relative to l.cfg.Dir.
 // If the path is a local import path naming a package that can be imported
 // using a standard import path, the returned package will set p.ImportPath
 // to that path.
@@ -111,10 +111,6 @@ func (l *loader) importPkg(pos token.Pos, p *build.Instance) []*build.Instance {
 	if p.PkgName != "" {
 		// If we have an explicit package name, we can ignore other packages.
 		fp.ignoreOther = true
-	}
-
-	if !strings.HasPrefix(p.Dir, cfg.ModuleRoot) {
-		panic("")
 	}
 
 	var dirs [][2]string

--- a/cue/load/import_test.go
+++ b/cue/load/import_test.go
@@ -34,8 +34,11 @@ func getInst(pkg, cwd string) (*build.Instance, error) {
 }
 
 func TestEmptyImport(t *testing.T) {
-	p, err := getInst("", "")
-	if err == nil {
+	c, _ := (&Config{}).complete()
+	l := loader{cfg: c}
+	inst := c.newInstance(token.NoPos, "")
+	p := l.importPkg(token.NoPos, inst)[0]
+	if p.Err == nil {
 		t.Fatal(`Import("") returned nil error.`)
 	}
 	if p == nil {

--- a/cue/load/loader.go
+++ b/cue/load/loader.go
@@ -156,12 +156,6 @@ func (l *loader) cueFilesPackage(files []*build.File) *build.Instance {
 	// ModInit() // TODO: support modules
 	pkg := l.cfg.Context.NewInstance(cfg.Dir, l.loadFunc())
 
-	_, err := filepath.Abs(cfg.Dir)
-	if err != nil {
-		return cfg.newErrInstance(pos, toImportPath(cfg.Dir),
-			errors.Wrapf(err, pos, "could not convert '%s' to absolute path", cfg.Dir))
-	}
-
 	for _, bf := range files {
 		f := bf.Filename
 		if f == "-" {

--- a/cue/load/search.go
+++ b/cue/load/search.go
@@ -197,14 +197,13 @@ func (l *loader) matchPackagesInFS(pattern, pkgName string) *match {
 		// silently skipped as not matching the pattern.
 		// Do not take root, as we want to stay relative
 		// to one dir only.
-		dir, e := filepath.Rel(c.Dir, path)
+		relPath, e := filepath.Rel(c.Dir, path)
 		if e != nil {
-			panic(err)
-		} else {
-			dir = "./" + dir
+			panic(err) // Should never happen because c.Dir is absolute.
 		}
+		relPath = "./" + filepath.ToSlash(relPath)
 		// TODO: consider not doing these checks here.
-		inst := c.newRelInstance(token.NoPos, dir, pkgName)
+		inst := c.newRelInstance(token.NoPos, relPath, pkgName)
 		pkgs := l.importPkg(token.NoPos, inst)
 		for _, p := range pkgs {
 			if err := p.Err; err != nil && (p == nil || len(p.InvalidFiles) == 0) {


### PR DESCRIPTION
This CL makes some mostly cosmetic changes that shouldn't influence
observable behaviour in practice.

- ensure that Config.ModuleRoot is always an absolute path - various
other places in the code already assume that it is (by checking that
it's a prefix of other absolute paths, for example, or by returning it where
an absolute path is expected).

- Close the `cue.mod` file after opening it.

- Factor out the sizable code block that sets Config.Module
into its own function so it's clearer what it's doing (and avoiding
the need for the slightly sleazy switch, used only so we can `break`
out of it.

- Remove places that needlessly check that Config.Dir is absolute.

- Make the contract for Config.newRelInstance clear, and change the only
place (a test) that calls it with an empty path, because it's clear by inspection
of all the call sites that it can never be called with an empty path in practice.

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: Id48c981b8fa2ebae56d88032c4b36de15888264f
