### PR TITLE
internal/core/adt: improve mechanism for conjunct insertion

### DIFF
--- a/cue/testdata/benchmarks/issue2176.txtar
+++ b/cue/testdata/benchmarks/issue2176.txtar
@@ -59,15 +59,15 @@ output: {
 	"2": (datastream & {marker: length: 14}).marker.position
 }
 -- out/eval/stats --
-Leaks:  214
-Freed:  5803
-Reused: 5798
-Allocs: 219
+Leaks:  218
+Freed:  5799
+Reused: 5795
+Allocs: 222
 Retain: 1077
 
 Unifications: 6009
 Conjuncts:    14515
-Disjuncts:    6872
+Disjuncts:    6868
 -- out/eval --
 (struct){
   #Datastream: (#struct){

--- a/cue/testdata/cycle/chain.txtar
+++ b/cue/testdata/cycle/chain.txtar
@@ -212,10 +212,10 @@ Leaks:  123
 Freed:  4431
 Reused: 4412
 Allocs: 142
-Retain: 693
+Retain: 689
 
 Unifications: 1799
-Conjuncts:    7513
+Conjuncts:    7509
 Disjuncts:    5078
 -- out/eval --
 (struct){

--- a/cue/testdata/cycle/evaluate.txtar
+++ b/cue/testdata/cycle/evaluate.txtar
@@ -111,7 +111,7 @@ Leaks:  67
 Freed:  94
 Reused: 90
 Allocs: 71
-Retain: 127
+Retain: 119
 
 Unifications: 149
 Conjuncts:    291

--- a/cue/testdata/cycle/inline_non_recursive.txtar
+++ b/cue/testdata/cycle/inline_non_recursive.txtar
@@ -60,15 +60,15 @@ issue1708: {
 }
 
 -- out/eval/stats --
-Leaks:  240
-Freed:  440
-Reused: 430
-Allocs: 250
+Leaks:  291
+Freed:  389
+Reused: 379
+Allocs: 301
 Retain: 1014
 
 Unifications: 680
 Conjuncts:    2709
-Disjuncts:    1454
+Disjuncts:    1403
 -- out/eval --
 (struct){
   ok1: (struct){

--- a/cue/testdata/cycle/self.txtar
+++ b/cue/testdata/cycle/self.txtar
@@ -344,6 +344,9 @@ Result:
           // [eval] list.error2.a: conflicting values "1" and "2":
           //     ./in.cue:16:6
           //     ./in.cue:16:11
+          // list.error2.a: conflicting values "3" and "1":
+          //     ./in.cue:15:6
+          //     ./in.cue:16:6
           // list.error2.a: conflicting values "3" and "2":
           //     ./in.cue:15:6
           //     ./in.cue:16:11

--- a/cue/testdata/cycle/structural.txtar
+++ b/cue/testdata/cycle/structural.txtar
@@ -536,7 +536,7 @@ Leaks:  17
 Freed:  791
 Reused: 779
 Allocs: 29
-Retain: 61
+Retain: 59
 
 Unifications: 622
 Conjuncts:    1219

--- a/cue/testdata/definitions/033_Issue_#153.txtar
+++ b/cue/testdata/definitions/033_Issue_#153.txtar
@@ -63,8 +63,8 @@ Junk: {
 -- out/eval/stats --
 Leaks:  0
 Freed:  15
-Reused: 7
-Allocs: 8
+Reused: 6
+Allocs: 9
 Retain: 4
 
 Unifications: 11

--- a/cue/testdata/definitions/037_closing_with_comprehensions.txtar
+++ b/cue/testdata/definitions/037_closing_with_comprehensions.txtar
@@ -103,15 +103,15 @@ a: _|_ // field "f3" not allowed in closed struct
   })
 }
 -- out/eval/stats --
-Leaks:  5
-Freed:  23
-Reused: 19
-Allocs: 9
+Leaks:  10
+Freed:  18
+Reused: 15
+Allocs: 13
 Retain: 11
 
 Unifications: 28
 Conjuncts:    43
-Disjuncts:    34
+Disjuncts:    29
 -- out/eval --
 Errors:
 #E.f3: field not allowed:

--- a/cue/testdata/definitions/files.txtar
+++ b/cue/testdata/definitions/files.txtar
@@ -29,13 +29,13 @@ package foo
 -- out/eval/stats --
 Leaks:  0
 Freed:  25
-Reused: 18
-Allocs: 7
-Retain: 4
+Reused: 19
+Allocs: 6
+Retain: 1
 
 Unifications: 21
 Conjuncts:    69
-Disjuncts:    29
+Disjuncts:    26
 -- out/eval --
 (#struct){
   #theme: (#struct){

--- a/cue/testdata/disjunctions/019_ips.txtar
+++ b/cue/testdata/disjunctions/019_ips.txtar
@@ -55,15 +55,15 @@ MyIP: [10, 10, 10, 10]
   ])
 }
 -- out/eval/stats --
-Leaks:  2
-Freed:  55
-Reused: 49
-Allocs: 8
+Leaks:  3
+Freed:  54
+Reused: 48
+Allocs: 9
 Retain: 10
 
 Unifications: 48
 Conjuncts:    111
-Disjuncts:    65
+Disjuncts:    64
 -- out/eval --
 (struct){
   IP: (#list){

--- a/cue/testdata/eval/bulk.txtar
+++ b/cue/testdata/eval/bulk.txtar
@@ -70,15 +70,15 @@ patternCycle: t1: p3: {
 }
 
 -- out/eval/stats --
-Leaks:  2
-Freed:  88
-Reused: 81
-Allocs: 9
-Retain: 8
+Leaks:  4
+Freed:  80
+Reused: 73
+Allocs: 11
+Retain: 12
 
-Unifications: 69
-Conjuncts:    135
-Disjuncts:    96
+Unifications: 63
+Conjuncts:    129
+Disjuncts:    90
 -- out/eval --
 Errors:
 t1.c.z: field not allowed:
@@ -189,9 +189,12 @@ Result:
           // [eval] patternCycle.issue2109.p2.countries: cyclic pattern constraint:
           //     ./issue2109.cue:15:15
           //     ./issue2109.cue:17:13
-          0: (string){ "US" }
-          1: (string){ "GB" }
-          2: (string){ "AU" }
+          0: (_|_){// "US"
+          }
+          1: (_|_){// "GB"
+          }
+          2: (_|_){// "AU"
+          }
         }
       }
       p3: (_|_){
@@ -202,9 +205,12 @@ Result:
           // [eval] patternCycle.issue2109.p3.countries: cyclic pattern constraint:
           //     ./issue2109.cue:21:15
           //     ./issue2109.cue:22:13
-          0: (string){ "US" }
-          1: (string){ "GB" }
-          2: (string){ "AU" }
+          0: (_|_){// "US"
+          }
+          1: (_|_){// "GB"
+          }
+          2: (_|_){// "AU"
+          }
         }
       }
     }

--- a/cue/testdata/eval/insertion.txtar
+++ b/cue/testdata/eval/insertion.txtar
@@ -96,29 +96,27 @@ embeddedFunctionalExpr: {
 	#fn
 }
 -- out/eval/stats --
-Leaks:  13
-Freed:  55
-Reused: 51
+Leaks:  12
+Freed:  53
+Reused: 48
 Allocs: 17
-Retain: 36
+Retain: 23
 
-Unifications: 68
-Conjuncts:    225
-Disjuncts:    87
+Unifications: 65
+Conjuncts:    191
+Disjuncts:    74
 -- out/eval --
 (struct){
   embeddingDirect: (struct){
-    t1: (_|_){
-      // [incomplete] embeddingDirect.t1: cannot add field #a: was already used:
-      //     ./a.cue:5:2
-      #a: (_){ _ }
+    t1: (string){
+      "s"
+      #a: (string){ string }
     }
   }
   embeddingExpr: (struct){
-    t1: (_|_){
-      // [incomplete] embeddingExpr.t1: cannot add field #a: was already used:
-      //     ./a.cue:13:2
-      #a: (_){ _ }
+    t1: (string){
+      "s"
+      #a: (string){ string }
     }
   }
   unifiedDirect: (struct){
@@ -134,18 +132,17 @@ Disjuncts:    87
     }
   }
   cross: (struct){
-    t1: (_|_){
-      // [incomplete] cross.t1: cannot add field a: was already used:
-      //     ./a.cue:52:13
-      // cross.t1: cannot add field a: was already used:
-      //     ./a.cue:56:3
+    t1: (struct){
       a: (struct){
         b: (struct){
           v: (int){ 1 }
           a: (struct){
             w: (int){ 2 }
           }
+          y: (int){ 5 }
         }
+        x: (int){ 2 }
+        w: (int){ 2 }
       }
       b: (struct){
         a: (struct){
@@ -156,19 +153,25 @@ Disjuncts:    87
           w: (int){ 2 }
         }
         v: (int){ 1 }
+        y: (int){ 5 }
       }
+      x: (int){ 2 }
+      y: (int){ 5 }
       v: (int){ 1 }
+      w: (int){ 2 }
     }
   }
   recursive: (struct){
     t1: (struct){
       e: (struct){
         f: (int){ 1 }
+        g: (int){ 1 }
       }
       c: (struct){
         d: (struct){
           e: (struct){
             f: (int){ 1 }
+            g: (int){ 1 }
           }
           c: (struct){
             d: (struct){
@@ -181,21 +184,13 @@ Disjuncts:    87
       }
     }
   }
-  embeddedFunctionalExpr: (_|_){
-    // [incomplete] embeddedFunctionalExpr: cannot add field #in: was already used:
-    //     ./issue2169.cue:6:3
-    // embeddedFunctionalExpr: non-concrete value _ in operand to +:
-    //     ./issue2169.cue:8:3
-    //     ./issue2169.cue:8:4
-    #fn: (_|_){
-      // [incomplete] embeddedFunctionalExpr.#fn: cannot add field #in: was already used:
-      //     ./issue2169.cue:6:3
-      // embeddedFunctionalExpr.#fn: non-concrete value _ in operand to +:
-      //     ./issue2169.cue:8:3
-      //     ./issue2169.cue:8:4
-      #in: (_){ _ }
+  embeddedFunctionalExpr: (string){
+    "str"
+    #fn: (string){
+      "str"
+      #in: (string){ string }
     }
-    #in: (_){ _ }
+    #in: (string){ string }
   }
 }
 -- out/compile --

--- a/cue/testdata/eval/structs.txtar
+++ b/cue/testdata/eval/structs.txtar
@@ -3,15 +3,15 @@ import "struct"
 
 v: {a: struct.MaxFields(2) & {}}.a
 -- out/eval/stats --
-Leaks:  1
-Freed:  3
+Leaks:  2
+Freed:  2
 Reused: 0
 Allocs: 4
 Retain: 2
 
 Unifications: 4
 Conjuncts:    7
-Disjuncts:    5
+Disjuncts:    4
 -- out/eval --
 (struct){
   v: (struct){

--- a/cue/testdata/export/009.txtar
+++ b/cue/testdata/export/009.txtar
@@ -43,15 +43,15 @@ f: [1, 2, ...]
   }
 }
 -- out/eval/stats --
-Leaks:  2
-Freed:  14
+Leaks:  3
+Freed:  13
 Reused: 10
 Allocs: 6
 Retain: 12
 
 Unifications: 16
 Conjuncts:    37
-Disjuncts:    26
+Disjuncts:    25
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/010.txtar
+++ b/cue/testdata/export/010.txtar
@@ -44,15 +44,15 @@ f: [1, 2, ...]
   }
 }
 -- out/eval/stats --
-Leaks:  2
-Freed:  14
+Leaks:  3
+Freed:  13
 Reused: 10
 Allocs: 6
 Retain: 12
 
 Unifications: 16
 Conjuncts:    37
-Disjuncts:    26
+Disjuncts:    25
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/issue2119.txtar
+++ b/cue/testdata/export/issue2119.txtar
@@ -33,15 +33,15 @@ original: {
 	out: yaml.Marshal(rule)
 }
 -- out/eval/stats --
-Leaks:  3
-Freed:  21
-Reused: 12
-Allocs: 12
+Leaks:  4
+Freed:  20
+Reused: 11
+Allocs: 13
 Retain: 4
 
 Unifications: 24
 Conjuncts:    42
-Disjuncts:    25
+Disjuncts:    24
 -- out/eval --
 (struct){
   simplified: (struct){

--- a/cue/testdata/fulleval/010_field_comprehensions_with_multiple_keys.txtar
+++ b/cue/testdata/fulleval/010_field_comprehensions_with_multiple_keys.txtar
@@ -169,15 +169,15 @@ C:
   }
 }
 -- out/eval/stats --
-Leaks:  2
-Freed:  47
-Reused: 29
-Allocs: 20
+Leaks:  20
+Freed:  29
+Reused: 25
+Allocs: 24
 Retain: 20
 
 Unifications: 49
-Conjuncts:    60
-Disjuncts:    55
+Conjuncts:    48
+Disjuncts:    37
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/lists/019_list_types.txtar
+++ b/cue/testdata/lists/019_list_types.txtar
@@ -117,15 +117,15 @@ e1: [..._|_ // conflicting values int and float (mismatched types int and float)
   ]
 }
 -- out/eval/stats --
-Leaks:  11
-Freed:  30
-Reused: 26
-Allocs: 15
+Leaks:  15
+Freed:  26
+Reused: 23
+Allocs: 18
 Retain: 34
 
 Unifications: 41
 Conjuncts:    75
-Disjuncts:    63
+Disjuncts:    59
 -- out/eval --
 Errors:
 e0: incompatible list lengths (1 and 2)

--- a/cue/testdata/packages/embed.txtar
+++ b/cue/testdata/packages/embed.txtar
@@ -24,15 +24,15 @@ package baz
 
 x: 1
 -- out/eval/stats --
-Leaks:  1
-Freed:  12
-Reused: 8
+Leaks:  2
+Freed:  9
+Reused: 6
 Allocs: 5
 Retain: 4
 
-Unifications: 13
-Conjuncts:    29
-Disjuncts:    16
+Unifications: 11
+Conjuncts:    27
+Disjuncts:    13
 -- out/eval --
 (struct){
   foo: (struct){

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -161,8 +161,15 @@ type Vertex struct {
 	// Label is the feature leading to this vertex.
 	Label Feature
 
+	// TODO: move the following status fields to nodeContext.
+
 	// status indicates the evaluation progress of this vertex.
 	status VertexStatus
+
+	// hasAllConjuncts indicates that the set of conjuncts is complete.
+	// This is the case if the conjuncts of all its ancestors have been
+	// processed.
+	hasAllConjuncts bool
 
 	// isData indicates that this Vertex is to be interepreted as data: pattern
 	// and additional constraints, as well as optional fields, should be
@@ -350,6 +357,27 @@ func (v *Vertex) UpdateStatus(s VertexStatus) {
 		// panic("not finalized")
 	}
 	v.status = s
+}
+
+// setParentDone signals v that the conjuncts of all ancestors have been
+// processed.
+// If all conjuncts of this node have been set, all arcs will be notified
+// of this parent being done.
+//
+// Note: once a vertex has started evaluation (state != nil), insertField will
+// cause all conjuncts to be immediately processed. This means that if all
+// ancestors of this node processed their conjuncts, and if this node has
+// processed all its conjuncts as well, all nodes that it embedded will have
+// received all their conjuncts as well, after which this node will have been
+// notified of these conjuncts.
+func (v *Vertex) setParentDone() {
+	v.hasAllConjuncts = true
+	// Could set "Conjuncts" flag of arc at this point.
+	if n := v.state; n != nil && len(n.conjuncts) == 0 {
+		for _, a := range v.Arcs {
+			a.setParentDone()
+		}
+	}
 }
 
 // Value returns the Value of v without definitions if it is a scalar
@@ -784,6 +812,28 @@ func (v *Vertex) addConjunctUnchecked(c Conjunct) {
 	v.Conjuncts = append(v.Conjuncts, c)
 	if n := v.state; n != nil {
 		n.conjuncts = append(n.conjuncts, c)
+		// TODO: can we remove notifyConjunct here? This method is only
+		// used if either Unprocessed is 0, in which case there will be no
+		// notification recipients, or for "pushed down" comprehensions,
+		// which should also have been added at an earlier point.
+		n.notifyConjunct(c)
+	}
+}
+
+// addConjunctDynamic adds a conjunct to a vertex and immediately evaluates
+// it, whilst doing the same for any vertices on the notify list, recursively.
+func (n *nodeContext) addConjunctDynamic(c Conjunct) {
+	n.node.Conjuncts = append(n.node.Conjuncts, c)
+	n.addExprConjunct(c, Partial)
+	n.notifyConjunct(c)
+
+}
+
+func (n *nodeContext) notifyConjunct(c Conjunct) {
+	for _, arc := range n.notify {
+		if !arc.hasConjunct(c) {
+			arc.state.addConjunctDynamic(c)
+		}
 	}
 }
 

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -731,6 +731,10 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 		DebugSortArcs(n.ctx, n.node)
 	}
 
+	if n.node.hasAllConjuncts || n.node.Parent == nil {
+		n.node.setParentDone()
+	}
+
 	// At this point, if this arc is of type arcVoid, it means that the value
 	// may still be modified by child arcs. So in this case we must now process
 	// all arcs to be sure we get the correct result.
@@ -1012,7 +1016,7 @@ type defaultInfo struct {
 }
 
 func (n *nodeContext) addNotify(v *Vertex) {
-	if v != nil {
+	if v != nil && !n.node.hasAllConjuncts {
 		n.notify = append(n.notify, v)
 	}
 }
@@ -1484,12 +1488,18 @@ func (n *nodeContext) evalExpr(v Conjunct, state VertexStatus) {
 		// We complete the evaluation. Some optimizations will only work when an
 		// arc is already finalized. So this ensures that such optimizations get
 		// triggered more often.
+		//
+		// NOTE(let finalization): aside from being an optimization, this also
+		// ensures that let arcs that are not contained as fields of arcs, but
+		// rather are held in the cash, are finalized. This, in turn, is
+		// necessary to trigger the notification mechanism, where appropriate.
+		//
 		// A node should not Finalize itself as it may erase the state object
-		// which is still assumed to be present down the line (see Issue #2171).
-		if arc.status == Conjuncts && arc != n.node {
+		// which is still assumed to be present down the line
+		// (see https://cuelang.org/issues/2171).
+		if arc.status == Conjuncts && arc != n.node && arc.hasAllConjuncts {
 			arc.Finalize(ctx)
 		}
-
 		ci, skip := n.markCycle(arc, v.Env, x, v.CloseInfo)
 		if skip {
 			return
@@ -1620,6 +1630,10 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 	// Don't add conjuncts if a node is referring to itself.
 	if n.node == arc {
 		return
+	}
+
+	if arc.state != nil {
+		arc.state.addNotify(n.node)
 	}
 
 	for _, c := range arc.Conjuncts {
@@ -1977,8 +1991,7 @@ func (n *nodeContext) insertField(f Feature, x Conjunct) *Vertex {
 
 	switch {
 	case arc.state != nil:
-		arc.Conjuncts = append(arc.Conjuncts, x)
-		arc.state.addExprConjunct(x, Partial)
+		arc.state.addConjunctDynamic(x)
 
 	case arc.Status() == 0:
 		arc.addConjunctUnchecked(x)

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -956,6 +956,17 @@ func (x *LetReference) resolve(ctx *OpContext, state VertexStatus) *Vertex {
 		e.cache[key] = n
 		nc := n.getNodeContext(ctx, 0)
 		nc.hasNonCycle = true // Allow a first cycle to be skipped.
+
+		// Parents cannot add more conjuncts to a let expression, so set of
+		// conjuncts is always complete.
+		//
+		// NOTE(let finalization): as this let expression is not recorded as
+		// a subfield within its parent arc, setParentDone will not be called
+		// as part of normal processing. The same is true for finalization.
+		// The use of setParentDone has the additional effect that the arc
+		// will be finalized where it is needed. See the namesake NOTE for the
+		// location where this is triggered.
+		n.setParentDone()
 	}
 	return v.(*Vertex)
 }


### PR DESCRIPTION
Before this change it was possible for reference
to be inserted into a vertex (possibly through
embedding) while the conjunct list of the arc was still
not completed. For instance, if a parent node was not
yet done processing conjuncts, it may be that the child
would also still get conjuncts.
This would cause conjuncts to be dropped during evaluation.

This change adds a mechanism to add conjuncts post hoc
to nodes that included the respective referenced Vertex.
Whenever a conjunct is added to an arc for which
processing has already started, it will proactively
evaluate the conjunct and add it to any nodes in
the notify list.
This will ensure, through a recursive process, that such
a conjunct is immediately added to all nodes that
require it.

In addition, each node tracks whether all conjuncts are
added. All conjuncts will have been added if both
- all its conjuncts are processed, and
- if all ancestor nodes have processed all their
  conjuncts.
This is a consequence of the abovementioned recursive
process.

The changes in bulk.txtar are okay, as the uninitialized
fields are below a field with a permanent error and do
not necessarily have to be evaluated. A TODO has been
added to remove the code that offends it. At the moment,
though, removing this code has too many adverse
consequences that will be mitigated by reworking the
state model.

Fixes #2169

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: I8e976f2b7c8dff73ac1520037bceed2c7d4f4d1c
