### PR TITLE
cmd/cue: add evaluator stats support

### DIFF
--- a/cmd/cue/cmd/testdata/script/stats.txtar
+++ b/cmd/cue/cmd/testdata/script/stats.txtar
@@ -1,0 +1,64 @@
+env CUE_STATS_FILE=stats.json
+exec cue eval x.cue
+cmp stats.json out/stats.json
+
+# overwrite existing files.
+env CUE_STATS_FILE=overwrite_stats.json
+exec cue eval x.cue
+cmp overwrite_stats.json out/stats.json
+
+env CUE_STATS_FILE=stats.cue
+exec cue eval x.cue
+cmp stats.cue out/stats.cue
+
+env CUE_STATS_FILE=stats.yaml
+exec cue eval x.cue
+cmp stats.yaml out/stats.yaml
+
+# default output is JSON.
+env CUE_STATS_FILE=-
+exec cue eval x.cue
+cmp stderr out/stderr
+
+-- x.cue --
+a: 1
+b: 2
+c: a | b
+-- overwrite_stats.json --
+contents overwritten
+-- out/stats.json --
+{
+    "Unifications": 4,
+    "Disjuncts": 6,
+    "Conjuncts": 8,
+    "Freed": 6,
+    "Reused": 2,
+    "Allocs": 4,
+    "Retained": 0
+}
+-- out/stats.cue --
+Unifications: 4
+Disjuncts:    6
+Conjuncts:    8
+Freed:        6
+Reused:       2
+Allocs:       4
+Retained:     0
+-- out/stats.yaml --
+Unifications: 4
+Disjuncts: 6
+Conjuncts: 8
+Freed: 6
+Reused: 2
+Allocs: 4
+Retained: 0
+-- out/stderr --
+{
+    "Unifications": 4,
+    "Disjuncts": 6,
+    "Conjuncts": 8,
+    "Freed": 6,
+    "Reused": 2,
+    "Allocs": 4,
+    "Retained": 0
+}

--- a/cue/context.go
+++ b/cue/context.go
@@ -245,7 +245,10 @@ func (c *Context) CompileBytes(b []byte, options ...BuildOption) Value {
 // }
 
 func (c *Context) make(v *adt.Vertex) Value {
-	return newValueRoot(c.runtime(), newContext(c.runtime()), v)
+	opCtx := newContext(c.runtime())
+	x := newValueRoot(c.runtime(), opCtx, v)
+	adt.AddStats(opCtx)
+	return x
 }
 
 // An EncodeOption defines options for the various encoding-related methods of

--- a/cue/instance.go
+++ b/cue/instance.go
@@ -210,6 +210,11 @@ func (inst *hiddenInstance) Doc() []*ast.CommentGroup {
 func (inst *Instance) Value() Value {
 	ctx := newContext(inst.index)
 	inst.root.Finalize(ctx)
+	// TODO: consider including these statistics as well. Right now, this only
+	// seems to be used in cue cmd for "auxiliary" evaluations, like filetypes.
+	// These arguably skew the actual statistics for the cue command line, so
+	// it is convenient to not include these.
+	// adt.AddStats(ctx)
 	return newVertexRoot(inst.index, ctx, inst.root)
 }
 

--- a/internal/core/adt/prof.go
+++ b/internal/core/adt/prof.go
@@ -1,0 +1,47 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adt
+
+import (
+	"sync"
+
+	"cuelang.org/go/cue/stats"
+)
+
+// This file contains stats and profiling functionality.
+
+var (
+	// counts is a temporary and internal solution for collecting global stats. It is protected with a mutex.
+	counts   stats.Counts
+	countsMu sync.Mutex
+)
+
+// AddStats adds the stats of the given OpContext to the global
+// counters.
+func AddStats(ctx *OpContext) {
+	countsMu.Lock()
+	counts.Add(ctx.stats)
+	countsMu.Unlock()
+}
+
+// TotalStats returns the aggregate counts of all operations
+// calling AddStats.
+func TotalStats() stats.Counts {
+	countsMu.Lock()
+	// Shallow copy suffices as it only contains counter fields.
+	s := counts
+	countsMu.Unlock()
+	return s
+}


### PR DESCRIPTION
This is mostly intended for more reliable performance
analysis in Unity.

This is an experimental feature that is really for
internal use only.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: If2447432c67c47f3d96f2722ca1e254bea4c8a54
