### PR TITLE
internal/ci: install cmd/cue before running "cue cmd"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,14 @@ jobs:
           registry: docker.io
           username: cueckoo
           password: ${{ secrets.CUECKOO_DOCKER_PAT }}
+      - name: Install CUE
+        run: go install cuelang.org/go/cmd/cue@v0.5.0-beta.2
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           install-only: true
           version: v1.13.1
-      - name: Run GoReleaser
+      - name: Run GoReleaser with CUE
         run: cue cmd release
         working-directory: ./internal/ci/goreleaser
         env:

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -62,6 +62,10 @@ release: _base.#bashWorkflow & {
 				}
 			},
 			json.#step & {
+				name: "Install CUE"
+				run:  "go install cuelang.org/go/cmd/cue@v0.5.0-beta.2"
+			},
+			json.#step & {
 				name: "Install GoReleaser"
 				uses: "goreleaser/goreleaser-action@v3"
 				with: {
@@ -70,7 +74,7 @@ release: _base.#bashWorkflow & {
 				}
 			},
 			json.#step & {
-				name: "Run GoReleaser"
+				name: "Run GoReleaser with CUE"
 				env: GITHUB_TOKEN: "${{ secrets.CUECKOO_GITHUB_PAT }}"
 				run:                 "cue cmd release"
 				"working-directory": "./internal/ci/goreleaser"


### PR DESCRIPTION
https://cuelang.org/cl/546920 switched to running goreleaser via CUE,
so that we can customize the configuration with CUE as a first step.
By the point we run "cue cmd release" on CI, both Go and goreleaser are
installed, but CUE itself is not. Install it.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I4e5f00abac4d87fbca2bcd27c4ddb24b4aaee6d4
