### PR TITLE
trybot/547012/d9233e61fce55e03788645c5087c85ef8f31dc57/547012/2

### DIFF
--- a/cue/ast/ast.go
+++ b/cue/ast/ast.go
@@ -317,7 +317,7 @@ type Field struct {
 
 	// No TokenPos: Value must be an StructLit with one field.
 	TokenPos token.Pos
-	Token    token.Token // ':' or '::', ILLEGAL implies ':'
+	Token    token.Token // Deprecated: always token.COLON
 
 	Value Expr // the value associated with this field.
 
@@ -540,8 +540,6 @@ func NewStruct(fields ...interface{}) *StructLit {
 				break inner
 			case token.Token:
 				switch x {
-				case token.ISA:
-					tok = x
 				case token.OPTION:
 					optional = token.Blank.Pos()
 				case token.COLON, token.ILLEGAL:

--- a/cue/format/node.go
+++ b/cue/format/node.go
@@ -119,7 +119,7 @@ func (f *formatter) walkDeclList(list []ast.Decl) {
 			if hasDocComments(x) {
 				switch x := list[i-1].(type) {
 				case *ast.Field:
-					if x.Token == token.ISA || internal.IsDefinition(x.Label) {
+					if internal.IsDefinition(x.Label) {
 						f.print(newsection)
 					}
 

--- a/cue/format/node_test.go
+++ b/cue/format/node_test.go
@@ -36,11 +36,11 @@ func TestInvalidAST(t *testing.T) {
 	}{{
 		desc: "label sequence for definition",
 		node: &ast.Field{Label: ident("foo"), Value: ast.NewStruct(
-			ident("bar"), token.ISA, &ast.StructLit{},
+			ident("#bar"), token.COLON, &ast.StructLit{},
 		)},
 		// Force a new struct.
 		out: `foo: {
-	bar :: {}
+	#bar: {}
 }`,
 	}, {
 		desc: "label with invalid identifier",

--- a/cue/parser/parser.go
+++ b/cue/parser/parser.go
@@ -908,7 +908,6 @@ func (p *parser) parseField() (decl ast.Decl) {
 			p.errf(l.Pos(), "square bracket must have exactly one element")
 		}
 
-		tok := p.tok
 		label, expr, _, ok := p.parseLabel(true)
 		if !ok || (p.tok != token.COLON && p.tok != token.OPTION) {
 			if expr == nil {
@@ -921,7 +920,7 @@ func (p *parser) parseField() (decl ast.Decl) {
 		m.Value = &ast.StructLit{Elts: []ast.Decl{field}}
 		m = field
 
-		if tok != token.LSS && p.tok == token.OPTION {
+		if p.tok == token.OPTION {
 			m.Optional = p.pos
 			p.next()
 		}

--- a/cue/parser/parser.go
+++ b/cue/parser/parser.go
@@ -872,7 +872,7 @@ func (p *parser) parseField() (decl ast.Decl) {
 	// allowComprehension = false
 
 	switch p.tok {
-	case token.COLON, token.ISA:
+	case token.COLON:
 	case token.COMMA:
 		p.expectComma() // sync parser.
 		fallthrough
@@ -898,13 +898,10 @@ func (p *parser) parseField() (decl ast.Decl) {
 
 	m.TokenPos = p.pos
 	m.Token = p.tok
-	if p.tok == token.ISA {
-		p.assertV0(p.pos, 2, 0, "'::'")
+	if p.tok != token.COLON {
+		p.errorExpected(pos, "':'")
 	}
-	if p.tok != token.COLON && p.tok != token.ISA {
-		p.errorExpected(pos, "':' or '::'")
-	}
-	p.next() // : or ::
+	p.next() // :
 
 	for {
 		if l, ok := m.Label.(*ast.ListLit); ok && len(l.Elts) != 1 {
@@ -913,7 +910,7 @@ func (p *parser) parseField() (decl ast.Decl) {
 
 		tok := p.tok
 		label, expr, _, ok := p.parseLabel(true)
-		if !ok || (p.tok != token.COLON && p.tok != token.ISA && p.tok != token.OPTION) {
+		if !ok || (p.tok != token.COLON && p.tok != token.OPTION) {
 			if expr == nil {
 				expr = p.parseRHS()
 			}
@@ -931,14 +928,11 @@ func (p *parser) parseField() (decl ast.Decl) {
 
 		m.TokenPos = p.pos
 		m.Token = p.tok
-		if p.tok == token.ISA {
-			p.assertV0(p.pos, 2, 0, "'::'")
-		}
-		if p.tok != token.COLON && p.tok != token.ISA {
+		if p.tok != token.COLON {
 			if p.tok.IsLiteral() {
-				p.errf(p.pos, "expected ':' or '::'; found %s", p.lit)
+				p.errf(p.pos, "expected ':'; found %s", p.lit)
 			} else {
-				p.errf(p.pos, "expected ':' or '::'; found %s", p.tok)
+				p.errf(p.pos, "expected ':'; found %s", p.tok)
 			}
 			break
 		}
@@ -1096,7 +1090,7 @@ func (p *parser) parseComprehensionClauses(first bool) (clauses []ast.Clause, c 
 			forPos := p.expect(token.FOR)
 			if first {
 				switch p.tok {
-				case token.COLON, token.ISA, token.BIND, token.OPTION,
+				case token.COLON, token.BIND, token.OPTION,
 					token.COMMA, token.EOF:
 					return nil, c
 				}
@@ -1126,7 +1120,7 @@ func (p *parser) parseComprehensionClauses(first bool) (clauses []ast.Clause, c 
 			ifPos := p.expect(token.IF)
 			if first {
 				switch p.tok {
-				case token.COLON, token.ISA, token.BIND, token.OPTION,
+				case token.COLON, token.BIND, token.OPTION,
 					token.COMMA, token.EOF:
 					return nil, c
 				}

--- a/cue/parser/parser_test.go
+++ b/cue/parser/parser_test.go
@@ -681,8 +681,6 @@ func TestStrict(t *testing.T) {
 			`a b c: 2`},
 		{"reserved identifiers",
 			`__foo: 3`},
-		{"old-style definition",
-			`foo :: 3`},
 		{"old-style alias 1",
 			`X=3`},
 		{"old-style alias 2",

--- a/cue/scanner/scanner.go
+++ b/cue/scanner/scanner.go
@@ -866,12 +866,7 @@ scanAgain:
 			insertEOL = true
 			tok, lit = s.scanAttribute()
 		case ':':
-			if s.ch == ':' {
-				s.next()
-				tok = token.ISA
-			} else {
-				tok = token.COLON
-			}
+			tok = token.COLON
 		case ';':
 			tok = token.SEMICOLON
 			insertEOL = true

--- a/cue/scanner/scanner_test.go
+++ b/cue/scanner/scanner_test.go
@@ -184,7 +184,6 @@ var testTokens = [...]elt{
 	{token.RBRACK, "]", operator},
 	{token.RBRACE, "}", operator},
 	{token.COLON, ":", operator},
-	{token.ISA, "::", operator},
 
 	// Keywords
 	{token.TRUE, "true", keyword},

--- a/cue/token/token.go
+++ b/cue/token/token.go
@@ -87,7 +87,6 @@ const (
 	RBRACE    // }
 	SEMICOLON // ;
 	COLON     // :
-	ISA       // ::
 	OPTION    // ?
 	operatorEnd
 
@@ -161,7 +160,6 @@ var tokens = [...]string{
 	RBRACE:    "}",
 	SEMICOLON: ";",
 	COLON:     ":",
-	ISA:       "::",
 	OPTION:    "?",
 
 	BOTTOM: "_|_",

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -595,15 +595,6 @@ func (c *compiler) decl(d ast.Decl) adt.Decl {
 				return c.errf(x, "cannot use _ as label")
 			}
 
-			// TODO(legacy): remove: old-school definitions
-			if x.Token == token.ISA && !label.IsDef() {
-				name, isIdent, err := ast.LabelName(lab)
-				if err == nil && isIdent {
-					idx := c.index.StringToIndex(name)
-					label, _ = adt.MakeLabel(x, idx, adt.DefinitionLabel)
-				}
-			}
-
 			if x.Optional == token.NoPos {
 				return &adt.Field{
 					Src:   x,
@@ -640,9 +631,6 @@ func (c *compiler) decl(d ast.Decl) adt.Decl {
 			}
 
 		case *ast.ParenExpr:
-			if x.Token == token.ISA {
-				c.errf(x, "definitions not supported for dynamic fields")
-			}
 			return &adt.DynamicField{
 				Src:   x,
 				Key:   c.expr(l),
@@ -650,9 +638,6 @@ func (c *compiler) decl(d ast.Decl) adt.Decl {
 			}
 
 		case *ast.Interpolation:
-			if x.Token == token.ISA {
-				c.errf(x, "definitions not supported for interpolations")
-			}
 			return &adt.DynamicField{
 				Src:   x,
 				Key:   c.expr(l),

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -422,8 +422,7 @@ func (v *validator) validate(n ast.Node) bool {
 		check(n, i.Imports, "imports", true)
 
 	case *ast.Field:
-		check(n, i.Definitions, "definitions",
-			x.Token == token.ISA || internal.IsDefinition(x.Label))
+		check(n, i.Definitions, "definitions", internal.IsDefinition(x.Label))
 		check(n, i.Data, "regular fields", internal.IsRegularField(x))
 		check(n, constraints, "optional fields", x.Optional != token.NoPos)
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -329,9 +329,6 @@ func IsDefinition(label ast.Label) bool {
 }
 
 func IsRegularField(f *ast.Field) bool {
-	if f.Token == token.ISA {
-		return false
-	}
 	var ident *ast.Ident
 	switch x := f.Label.(type) {
 	case *ast.Alias:


### PR DESCRIPTION
- all: remove support for ::
- cue/parser: remove last vestiges of <foo>: T
- cue/scanner: remove block comment scanning
