### PR TITLE
internal/core/adt: fix 2235

### DIFF
--- a/cue/testdata/basicrewrite/018_self-reference_cycles.txtar
+++ b/cue/testdata/basicrewrite/018_self-reference_cycles.txtar
@@ -28,10 +28,10 @@ Leaks:  0
 Freed:  6
 Reused: 2
 Allocs: 4
-Retain: 7
+Retain: 11
 
 Unifications: 6
-Conjuncts:    22
+Conjuncts:    26
 Disjuncts:    7
 -- out/eval --
 (struct){

--- a/cue/testdata/basicrewrite/aliases/aliases.txtar
+++ b/cue/testdata/basicrewrite/aliases/aliases.txtar
@@ -28,7 +28,7 @@ Leaks:  0
 Freed:  9
 Reused: 4
 Allocs: 5
-Retain: 2
+Retain: 3
 
 Unifications: 9
 Conjuncts:    15

--- a/cue/testdata/benchmarks/issue2176.txtar
+++ b/cue/testdata/benchmarks/issue2176.txtar
@@ -63,7 +63,7 @@ Leaks:  218
 Freed:  5799
 Reused: 5795
 Allocs: 222
-Retain: 1077
+Retain: 1915
 
 Unifications: 6009
 Conjuncts:    14515

--- a/cue/testdata/builtins/incomplete.txtar
+++ b/cue/testdata/builtins/incomplete.txtar
@@ -105,11 +105,11 @@ Leaks:  7
 Freed:  122
 Reused: 117
 Allocs: 12
-Retain: 32
+Retain: 54
 
 Unifications: 109
 Conjuncts:    267
-Disjuncts:    150
+Disjuncts:    156
 -- out/eval --
 Errors:
 badListType.decimal: cannot use 2 (type int) as list in argument 1 to list.Max:

--- a/cue/testdata/compile/scope.txtar
+++ b/cue/testdata/compile/scope.txtar
@@ -82,11 +82,11 @@ Leaks:  2
 Freed:  50
 Reused: 47
 Allocs: 5
-Retain: 7
+Retain: 8
 
 Unifications: 52
 Conjuncts:    107
-Disjuncts:    55
+Disjuncts:    56
 -- out/eval --
 Errors:
 schema.next: structural cycle

--- a/cue/testdata/comprehensions/015_list_comprehension.txtar
+++ b/cue/testdata/comprehensions/015_list_comprehension.txtar
@@ -85,11 +85,11 @@ Leaks:  0
 Freed:  19
 Reused: 11
 Allocs: 8
-Retain: 5
+Retain: 14
 
 Unifications: 19
 Conjuncts:    39
-Disjuncts:    20
+Disjuncts:    23
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/comprehensions/045_comprehension_and_skipped_field.txtar
+++ b/cue/testdata/comprehensions/045_comprehension_and_skipped_field.txtar
@@ -54,11 +54,11 @@ Leaks:  3
 Freed:  7
 Reused: 2
 Allocs: 8
-Retain: 3
+Retain: 8
 
 Unifications: 8
 Conjuncts:    11
-Disjuncts:    10
+Disjuncts:    13
 -- out/eval --
 (struct){
   x: (struct){

--- a/cue/testdata/comprehensions/checkdefined.txtar
+++ b/cue/testdata/comprehensions/checkdefined.txtar
@@ -77,11 +77,11 @@ Leaks:  11
 Freed:  81
 Reused: 77
 Allocs: 15
-Retain: 22
+Retain: 24
 
 Unifications: 92
 Conjuncts:    116
-Disjuncts:    96
+Disjuncts:    97
 -- out/eval --
 (struct){
   xc: (#struct){

--- a/cue/testdata/comprehensions/closed.txtar
+++ b/cue/testdata/comprehensions/closed.txtar
@@ -95,11 +95,11 @@ Leaks:  2
 Freed:  70
 Reused: 63
 Allocs: 9
-Retain: 10
+Retain: 15
 
 Unifications: 58
 Conjuncts:    104
-Disjuncts:    77
+Disjuncts:    81
 -- out/eval --
 Errors:
 disallowed.vErr.d: field not allowed:

--- a/cue/testdata/comprehensions/for.txtar
+++ b/cue/testdata/comprehensions/for.txtar
@@ -17,7 +17,7 @@ Leaks:  4
 Freed:  16
 Reused: 12
 Allocs: 8
-Retain: 9
+Retain: 11
 
 Unifications: 20
 Conjuncts:    20

--- a/cue/testdata/comprehensions/iferror.txtar
+++ b/cue/testdata/comprehensions/iferror.txtar
@@ -151,11 +151,11 @@ Leaks:  0
 Freed:  43
 Reused: 35
 Allocs: 8
-Retain: 15
+Retain: 22
 
 Unifications: 33
 Conjuncts:    68
-Disjuncts:    53
+Disjuncts:    60
 -- out/eval --
 Errors:
 issue1972.err1: conflicting values [] and {someCondition:_,patchs:[...{}],patchs,if someCondition {patchs:_}} (mismatched types list and struct):

--- a/cue/testdata/comprehensions/issue1732.txtar
+++ b/cue/testdata/comprehensions/issue1732.txtar
@@ -126,11 +126,11 @@ Leaks:  4
 Freed:  118
 Reused: 105
 Allocs: 17
-Retain: 10
+Retain: 19
 
 Unifications: 112
 Conjuncts:    249
-Disjuncts:    126
+Disjuncts:    133
 -- out/eval --
 (struct){
   networkingv1: (struct){

--- a/cue/testdata/comprehensions/issue2171.txtar
+++ b/cue/testdata/comprehensions/issue2171.txtar
@@ -25,11 +25,11 @@ Leaks:  0
 Freed:  3
 Reused: 0
 Allocs: 3
-Retain: 1
+Retain: 2
 
 Unifications: 3
 Conjuncts:    5
-Disjuncts:    4
+Disjuncts:    5
 -- out/eval --
 (struct){
   do: (struct){

--- a/cue/testdata/comprehensions/issue287.txtar
+++ b/cue/testdata/comprehensions/issue287.txtar
@@ -12,7 +12,7 @@ Leaks:  0
 Freed:  5
 Reused: 1
 Allocs: 4
-Retain: 1
+Retain: 2
 
 Unifications: 5
 Conjuncts:    8

--- a/cue/testdata/comprehensions/issue837.txtar
+++ b/cue/testdata/comprehensions/issue837.txtar
@@ -68,11 +68,11 @@ Leaks:  16
 Freed:  117
 Reused: 108
 Allocs: 25
-Retain: 68
+Retain: 123
 
 Unifications: 107
 Conjuncts:    295
-Disjuncts:    185
+Disjuncts:    240
 -- out/eval --
 Errors:
 #Configure.service.description.role: undefined field: role:

--- a/cue/testdata/comprehensions/issue843.txtar
+++ b/cue/testdata/comprehensions/issue843.txtar
@@ -45,11 +45,11 @@ Leaks:  9
 Freed:  55
 Reused: 41
 Allocs: 23
-Retain: 16
+Retain: 20
 
 Unifications: 52
 Conjuncts:    120
-Disjuncts:    65
+Disjuncts:    66
 -- out/eval --
 (struct){
   #d1: (#struct){

--- a/cue/testdata/comprehensions/nested.txtar
+++ b/cue/testdata/comprehensions/nested.txtar
@@ -63,11 +63,11 @@ Leaks:  0
 Freed:  45
 Reused: 26
 Allocs: 19
-Retain: 13
+Retain: 36
 
 Unifications: 35
 Conjuncts:    96
-Disjuncts:    57
+Disjuncts:    78
 -- out/eval --
 (struct){
   service: (struct){

--- a/cue/testdata/comprehensions/nested2.txtar
+++ b/cue/testdata/comprehensions/nested2.txtar
@@ -100,7 +100,7 @@ Leaks:  0
 Freed:  43
 Reused: 38
 Allocs: 5
-Retain: 5
+Retain: 6
 
 Unifications: 43
 Conjuncts:    78

--- a/cue/testdata/comprehensions/pushdown.txtar
+++ b/cue/testdata/comprehensions/pushdown.txtar
@@ -746,11 +746,11 @@ Leaks:  17
 Freed:  392
 Reused: 386
 Allocs: 23
-Retain: 70
+Retain: 134
 
 Unifications: 395
 Conjuncts:    646
-Disjuncts:    440
+Disjuncts:    483
 -- out/eval --
 Errors:
 embed.fail1.p: field not allowed:

--- a/cue/testdata/cycle/015_reference_across_tuples_and_back.txtar
+++ b/cue/testdata/cycle/015_reference_across_tuples_and_back.txtar
@@ -51,11 +51,11 @@ Leaks:  0
 Freed:  7
 Reused: 1
 Allocs: 6
-Retain: 3
+Retain: 8
 
 Unifications: 7
 Conjuncts:    13
-Disjuncts:    9
+Disjuncts:    12
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/cycle/023_reentrance.txtar
+++ b/cue/testdata/cycle/023_reentrance.txtar
@@ -67,11 +67,11 @@ Leaks:  16
 Freed:  180
 Reused: 169
 Allocs: 27
-Retain: 105
+Retain: 224
 
 Unifications: 196
 Conjuncts:    464
-Disjuncts:    276
+Disjuncts:    292
 -- out/eval --
 Errors:
 structural cycle:

--- a/cue/testdata/cycle/025_cannot_resolve_references_that_would_be_ambiguous.txtar
+++ b/cue/testdata/cycle/025_cannot_resolve_references_that_would_be_ambiguous.txtar
@@ -58,10 +58,10 @@ Leaks:  0
 Freed:  48
 Reused: 39
 Allocs: 9
-Retain: 4
+Retain: 12
 
 Unifications: 24
-Conjuncts:    71
+Conjuncts:    72
 Disjuncts:    46
 -- out/eval --
 (struct){

--- a/cue/testdata/cycle/051_resolved_self-reference_cycles_with_disjunction.txtar
+++ b/cue/testdata/cycle/051_resolved_self-reference_cycles_with_disjunction.txtar
@@ -172,7 +172,7 @@ Leaks:  5
 Freed:  47
 Reused: 40
 Allocs: 12
-Retain: 27
+Retain: 36
 
 Unifications: 31
 Conjuncts:    133

--- a/cue/testdata/cycle/052_resolved_self-reference_cycles_with_disjunction_with_defaults.txtar
+++ b/cue/testdata/cycle/052_resolved_self-reference_cycles_with_disjunction_with_defaults.txtar
@@ -129,7 +129,7 @@ Leaks:  6
 Freed:  38
 Reused: 34
 Allocs: 10
-Retain: 29
+Retain: 38
 
 Unifications: 27
 Conjuncts:    93

--- a/cue/testdata/cycle/builtins.txtar
+++ b/cue/testdata/cycle/builtins.txtar
@@ -73,11 +73,11 @@ Leaks:  0
 Freed:  37
 Reused: 30
 Allocs: 7
-Retain: 26
+Retain: 34
 
 Unifications: 37
 Conjuncts:    61
-Disjuncts:    57
+Disjuncts:    61
 -- out/eval --
 (struct){
   builtinCyclePerm0: (struct){

--- a/cue/testdata/cycle/chain.txtar
+++ b/cue/testdata/cycle/chain.txtar
@@ -212,11 +212,11 @@ Leaks:  123
 Freed:  4431
 Reused: 4412
 Allocs: 142
-Retain: 689
+Retain: 720
 
 Unifications: 1799
-Conjuncts:    7509
-Disjuncts:    5078
+Conjuncts:    7517
+Disjuncts:    5086
 -- out/eval --
 (struct){
   chain: (struct){

--- a/cue/testdata/cycle/compbottom.txtar
+++ b/cue/testdata/cycle/compbottom.txtar
@@ -259,11 +259,11 @@ Leaks:  0
 Freed:  85
 Reused: 73
 Allocs: 12
-Retain: 64
+Retain: 200
 
 Unifications: 85
-Conjuncts:    149
-Disjuncts:    111
+Conjuncts:    152
+Disjuncts:    194
 -- out/eval --
 (struct){
   simple: (struct){

--- a/cue/testdata/cycle/compbottom2.txtar
+++ b/cue/testdata/cycle/compbottom2.txtar
@@ -267,11 +267,11 @@ Leaks:  3
 Freed:  141
 Reused: 132
 Allocs: 12
-Retain: 35
+Retain: 66
 
 Unifications: 144
 Conjuncts:    159
-Disjuncts:    163
+Disjuncts:    186
 -- out/eval --
 (struct){
   self: (struct){

--- a/cue/testdata/cycle/compbottomnofinal.txtar
+++ b/cue/testdata/cycle/compbottomnofinal.txtar
@@ -361,11 +361,11 @@ Leaks:  16
 Freed:  95
 Reused: 84
 Allocs: 27
-Retain: 129
+Retain: 292
 
 Unifications: 111
-Conjuncts:    194
-Disjuncts:    130
+Conjuncts:    227
+Disjuncts:    206
 -- out/eval --
 (struct){
   minimal: (struct){

--- a/cue/testdata/cycle/comprehension.txtar
+++ b/cue/testdata/cycle/comprehension.txtar
@@ -308,11 +308,11 @@ Leaks:  48
 Freed:  1268
 Reused: 1256
 Allocs: 60
-Retain: 125
+Retain: 198
 
 Unifications: 828
-Conjuncts:    2521
-Disjuncts:    1377
+Conjuncts:    2522
+Disjuncts:    1443
 -- out/eval --
 Errors:
 selfReferential.insertionError.A: field foo3 not allowed by earlier comprehension or reference cycle

--- a/cue/testdata/cycle/evaluate.txtar
+++ b/cue/testdata/cycle/evaluate.txtar
@@ -111,7 +111,7 @@ Leaks:  67
 Freed:  94
 Reused: 90
 Allocs: 71
-Retain: 119
+Retain: 137
 
 Unifications: 149
 Conjuncts:    291

--- a/cue/testdata/cycle/expression.txtar
+++ b/cue/testdata/cycle/expression.txtar
@@ -100,10 +100,10 @@ Leaks:  0
 Freed:  58
 Reused: 49
 Allocs: 9
-Retain: 41
+Retain: 71
 
 Unifications: 58
-Conjuncts:    424
+Conjuncts:    427
 Disjuncts:    75
 -- out/eval --
 (struct){

--- a/cue/testdata/cycle/inline.txtar
+++ b/cue/testdata/cycle/inline.txtar
@@ -157,11 +157,11 @@ Leaks:  247
 Freed:  141
 Reused: 136
 Allocs: 252
-Retain: 734
+Retain: 834
 
 Unifications: 388
-Conjuncts:    1297
-Disjuncts:    688
+Conjuncts:    1307
+Disjuncts:    707
 -- out/eval --
 Errors:
 structural cycle:

--- a/cue/testdata/cycle/inline_non_recursive.txtar
+++ b/cue/testdata/cycle/inline_non_recursive.txtar
@@ -64,11 +64,11 @@ Leaks:  291
 Freed:  389
 Reused: 379
 Allocs: 301
-Retain: 1014
+Retain: 1047
 
 Unifications: 680
 Conjuncts:    2709
-Disjuncts:    1403
+Disjuncts:    1414
 -- out/eval --
 (struct){
   ok1: (struct){

--- a/cue/testdata/cycle/issue241.txtar
+++ b/cue/testdata/cycle/issue241.txtar
@@ -28,10 +28,10 @@ Leaks:  0
 Freed:  35
 Reused: 29
 Allocs: 6
-Retain: 4
+Retain: 5
 
 Unifications: 11
-Conjuncts:    69
+Conjuncts:    70
 Disjuncts:    33
 -- out/eval --
 (struct){

--- a/cue/testdata/cycle/issue242.txtar
+++ b/cue/testdata/cycle/issue242.txtar
@@ -91,11 +91,11 @@ Leaks:  0
 Freed:  78
 Reused: 68
 Allocs: 10
-Retain: 9
+Retain: 18
 
 Unifications: 26
 Conjuncts:    191
-Disjuncts:    79
+Disjuncts:    82
 -- out/eval --
 (struct){
   #size: (int){ 2 }

--- a/cue/testdata/cycle/issue429.txtar
+++ b/cue/testdata/cycle/issue429.txtar
@@ -53,10 +53,10 @@ Leaks:  0
 Freed:  96
 Reused: 89
 Allocs: 7
-Retain: 7
+Retain: 8
 
 Unifications: 40
-Conjuncts:    149
+Conjuncts:    150
 Disjuncts:    96
 -- out/eval --
 Errors:

--- a/cue/testdata/cycle/issue494.txtar
+++ b/cue/testdata/cycle/issue494.txtar
@@ -32,7 +32,7 @@ Retain: 0
 
 Unifications: 43
 Conjuncts:    83
-Disjuncts:    43
+Disjuncts:    45
 -- out/eval --
 Errors:
 f.ben: incompatible list lengths (1 and 2)

--- a/cue/testdata/cycle/issue990.txtar
+++ b/cue/testdata/cycle/issue990.txtar
@@ -177,11 +177,11 @@ Leaks:  6
 Freed:  3932
 Reused: 3909
 Allocs: 29
-Retain: 26
+Retain: 43
 
 Unifications: 3116
 Conjuncts:    15808
-Disjuncts:    3958
+Disjuncts:    3975
 -- out/eval --
 (struct){
   #AC: (#struct){

--- a/cue/testdata/cycle/self.txtar
+++ b/cue/testdata/cycle/self.txtar
@@ -267,11 +267,11 @@ Leaks:  14
 Freed:  414
 Reused: 405
 Allocs: 23
-Retain: 33
+Retain: 42
 
 Unifications: 236
 Conjuncts:    687
-Disjuncts:    435
+Disjuncts:    439
 -- out/eval --
 Errors:
 expr.error1.a: conflicting values 4 and 3:
@@ -344,9 +344,6 @@ Result:
           // [eval] list.error2.a: conflicting values "1" and "2":
           //     ./in.cue:16:6
           //     ./in.cue:16:11
-          // list.error2.a: conflicting values "3" and "1":
-          //     ./in.cue:15:6
-          //     ./in.cue:16:6
           // list.error2.a: conflicting values "3" and "2":
           //     ./in.cue:15:6
           //     ./in.cue:16:11

--- a/cue/testdata/cycle/structural.txtar
+++ b/cue/testdata/cycle/structural.txtar
@@ -536,11 +536,11 @@ Leaks:  17
 Freed:  791
 Reused: 779
 Allocs: 29
-Retain: 59
+Retain: 66
 
 Unifications: 622
 Conjuncts:    1219
-Disjuncts:    837
+Disjuncts:    841
 -- out/eval --
 Errors:
 a1.f.0: structural cycle

--- a/cue/testdata/definitions/033_Issue_#153.txtar
+++ b/cue/testdata/definitions/033_Issue_#153.txtar
@@ -65,7 +65,7 @@ Leaks:  0
 Freed:  15
 Reused: 6
 Allocs: 9
-Retain: 4
+Retain: 5
 
 Unifications: 11
 Conjuncts:    24

--- a/cue/testdata/definitions/037_closing_with_comprehensions.txtar
+++ b/cue/testdata/definitions/037_closing_with_comprehensions.txtar
@@ -107,11 +107,11 @@ Leaks:  10
 Freed:  18
 Reused: 15
 Allocs: 13
-Retain: 11
+Retain: 16
 
 Unifications: 28
 Conjuncts:    43
-Disjuncts:    29
+Disjuncts:    34
 -- out/eval --
 Errors:
 #E.f3: field not allowed:

--- a/cue/testdata/definitions/comprehensions.txtar
+++ b/cue/testdata/definitions/comprehensions.txtar
@@ -14,11 +14,11 @@ Leaks:  0
 Freed:  6
 Reused: 1
 Allocs: 5
-Retain: 2
+Retain: 6
 
 Unifications: 6
 Conjuncts:    9
-Disjuncts:    8
+Disjuncts:    12
 -- out/eval --
 Errors:
 issue595.files: undefined field: nam:

--- a/cue/testdata/definitions/issue342.txtar
+++ b/cue/testdata/definitions/issue342.txtar
@@ -32,7 +32,7 @@ Leaks:  0
 Freed:  24
 Reused: 17
 Allocs: 7
-Retain: 1
+Retain: 2
 
 Unifications: 18
 Conjuncts:    34

--- a/cue/testdata/disjunctions/019_ips.txtar
+++ b/cue/testdata/disjunctions/019_ips.txtar
@@ -59,11 +59,11 @@ Leaks:  3
 Freed:  54
 Reused: 48
 Allocs: 9
-Retain: 10
+Retain: 14
 
 Unifications: 48
 Conjuncts:    111
-Disjuncts:    64
+Disjuncts:    68
 -- out/eval --
 (struct){
   IP: (#list){

--- a/cue/testdata/disjunctions/elimination.txtar
+++ b/cue/testdata/disjunctions/elimination.txtar
@@ -381,11 +381,11 @@ Leaks:  0
 Freed:  2035
 Reused: 2015
 Allocs: 20
-Retain: 35
+Retain: 67
 
 Unifications: 1066
 Conjuncts:    2882
-Disjuncts:    2070
+Disjuncts:    2102
 -- out/eval --
 (struct){
   disambiguateClosed: (struct){

--- a/cue/testdata/eval/closedness.txtar
+++ b/cue/testdata/eval/closedness.txtar
@@ -47,7 +47,7 @@ Leaks:  0
 Freed:  27
 Reused: 21
 Allocs: 6
-Retain: 3
+Retain: 4
 
 Unifications: 27
 Conjuncts:    42

--- a/cue/testdata/eval/comprehensions.txtar
+++ b/cue/testdata/eval/comprehensions.txtar
@@ -102,7 +102,7 @@ Leaks:  4
 Freed:  64
 Reused: 57
 Allocs: 11
-Retain: 18
+Retain: 20
 
 Unifications: 68
 Conjuncts:    96

--- a/cue/testdata/eval/discontinuous.txtar
+++ b/cue/testdata/eval/discontinuous.txtar
@@ -53,11 +53,11 @@ Leaks:  0
 Freed:  14
 Reused: 5
 Allocs: 9
-Retain: 9
+Retain: 10
 
 Unifications: 14
 Conjuncts:    23
-Disjuncts:    23
+Disjuncts:    24
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/eval/dynamic_field.txtar
+++ b/cue/testdata/eval/dynamic_field.txtar
@@ -68,11 +68,11 @@ Leaks:  2
 Freed:  54
 Reused: 47
 Allocs: 9
-Retain: 6
+Retain: 9
 
 Unifications: 56
 Conjuncts:    73
-Disjuncts:    58
+Disjuncts:    61
 -- out/eval --
 Errors:
 invalid interpolation: conflicting values 2 and 1:

--- a/cue/testdata/eval/incomplete.txtar
+++ b/cue/testdata/eval/incomplete.txtar
@@ -48,11 +48,11 @@ Leaks:  5
 Freed:  27
 Reused: 21
 Allocs: 11
-Retain: 45
+Retain: 114
 
 Unifications: 32
-Conjuncts:    122
-Disjuncts:    35
+Conjuncts:    167
+Disjuncts:    59
 -- out/eval --
 (struct){
   s: (string){ string }

--- a/cue/testdata/eval/insertion.txtar
+++ b/cue/testdata/eval/insertion.txtar
@@ -100,11 +100,11 @@ Leaks:  12
 Freed:  53
 Reused: 48
 Allocs: 17
-Retain: 23
+Retain: 31
 
 Unifications: 65
 Conjuncts:    191
-Disjuncts:    74
+Disjuncts:    77
 -- out/eval --
 (struct){
   embeddingDirect: (struct){

--- a/cue/testdata/eval/issue2146.txtar
+++ b/cue/testdata/eval/issue2146.txtar
@@ -44,7 +44,7 @@ Leaks:  37
 Freed:  143
 Reused: 134
 Allocs: 46
-Retain: 100
+Retain: 154
 
 Unifications: 164
 Conjuncts:    544

--- a/cue/testdata/eval/issue2235.txtar
+++ b/cue/testdata/eval/issue2235.txtar
@@ -101,24 +101,16 @@ for clusterName, cluster in clusters {
 clusters: foo: {}
 -- out/eval/stats --
 Leaks:  3
-Freed:  94
-Reused: 68
-Allocs: 29
-Retain: 67
+Freed:  101
+Reused: 76
+Allocs: 28
+Retain: 128
 
-Unifications: 97
-Conjuncts:    256
-Disjuncts:    157
+Unifications: 104
+Conjuncts:    273
+Disjuncts:    200
 -- out/eval --
-Errors:
-clusters.foo.globalIngressControllers.admin.objects.namespaced.ingress.Service: cannot add to field svc
-t1.x: cannot add to field params
-t2.m: cannot add to field X
-t3.foo: cannot add to field out
-
-Result:
-(_|_){
-  // [eval]
+(struct){
   shorewallParams: (#struct){
     KUBERNETES_FOO_INGRESS_ADMIN: (#list){
       0: (string){ "127.0.0.1" }
@@ -180,10 +172,8 @@ Result:
       }
     }
   }
-  clusters: (_|_){
-    // [eval]
-    foo: (_|_){
-      // [eval]
+  clusters: (struct){
+    foo: (#struct){
       clusterName: (string){ "foo" }
       shorewallPrefix: (string){ "KUBERNETES_FOO" }
       objects: (#struct){
@@ -207,19 +197,13 @@ Result:
           }
         }
       }
-      globalIngressControllers: (_|_){
-        // [eval]
-        admin: (_|_){
-          // [eval]
+      globalIngressControllers: (#struct){
+        admin: (#struct){
           class: (string){ "admin" }
-          objects: (_|_){
-            // [eval]
-            namespaced: (_|_){
-              // [eval]
-              ingress: (_|_){
-                // [eval]
-                Service: (_|_){
-                  // [eval] clusters.foo.globalIngressControllers.admin.objects.namespaced.ingress.Service: cannot add to field svc
+          objects: (#struct){
+            namespaced: (#struct){
+              ingress: (#struct){
+                Service: (#struct){
                   "admin-nginx-ingress-controller": (#struct){
                     spec: (#struct){
                       externalIPs: (#list){
@@ -261,28 +245,30 @@ Result:
       }
     }
   }
-  t1: (_|_){
-    // [eval]
+  t1: (struct){
     params: (struct){
+      a: (struct){
+      }
     }
-    x: (_|_){
-      // [eval] t1.x: cannot add to field params
+    x: (struct){
       y: (struct){
         a: (struct){
         }
       }
     }
   }
-  t2: (_|_){
-    // [eval]
+  t2: (struct){
     out: (struct){
+      z: (struct){
+      }
     }
     let X#2 = (struct){
       y: (struct){
+        z: (struct){
+        }
       }
     }
-    m: (_|_){
-      // [eval] t2.m: cannot add to field X
+    m: (struct){
       x: (struct){
         y: (struct){
           z: (struct){
@@ -291,12 +277,10 @@ Result:
       }
     }
   }
-  t3: (_|_){
-    // [eval]
+  t3: (struct){
     out: (struct){
     }
-    foo: (_|_){
-      // [eval] t3.foo: cannot add to field out
+    foo: (struct){
       bar: (struct){
       }
     }

--- a/cue/testdata/eval/issue494.txtar
+++ b/cue/testdata/eval/issue494.txtar
@@ -23,7 +23,7 @@ Retain: 0
 
 Unifications: 26
 Conjuncts:    56
-Disjuncts:    26
+Disjuncts:    28
 -- out/eval --
 (struct){
   _Q: (#list){

--- a/cue/testdata/eval/issue500.txtar
+++ b/cue/testdata/eval/issue500.txtar
@@ -24,7 +24,7 @@ Leaks:  16
 Freed:  34
 Reused: 31
 Allocs: 19
-Retain: 27
+Retain: 37
 
 Unifications: 50
 Conjuncts:    66

--- a/cue/testdata/eval/let.txtar
+++ b/cue/testdata/eval/let.txtar
@@ -163,11 +163,11 @@ Leaks:  53
 Freed:  159
 Reused: 150
 Allocs: 62
-Retain: 151
+Retain: 236
 
 Unifications: 198
 Conjuncts:    384
-Disjuncts:    240
+Disjuncts:    249
 -- out/eval --
 Errors:
 indirectReference.y: conflicting values 2 and 1:

--- a/cue/testdata/eval/lists.txtar
+++ b/cue/testdata/eval/lists.txtar
@@ -12,7 +12,7 @@ Leaks:  4
 Freed:  11
 Reused: 8
 Allocs: 7
-Retain: 5
+Retain: 8
 
 Unifications: 15
 Conjuncts:    30

--- a/cue/testdata/eval/merge.txtar
+++ b/cue/testdata/eval/merge.txtar
@@ -24,11 +24,11 @@ Leaks:  0
 Freed:  22
 Reused: 12
 Allocs: 10
-Retain: 4
+Retain: 9
 
 Unifications: 22
 Conjuncts:    38
-Disjuncts:    25
+Disjuncts:    27
 -- out/eval --
 (struct){
   results: (struct){

--- a/cue/testdata/export/009.txtar
+++ b/cue/testdata/export/009.txtar
@@ -47,11 +47,11 @@ Leaks:  3
 Freed:  13
 Reused: 10
 Allocs: 6
-Retain: 12
+Retain: 17
 
 Unifications: 16
 Conjuncts:    37
-Disjuncts:    25
+Disjuncts:    30
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/010.txtar
+++ b/cue/testdata/export/010.txtar
@@ -48,11 +48,11 @@ Leaks:  3
 Freed:  13
 Reused: 10
 Allocs: 6
-Retain: 12
+Retain: 17
 
 Unifications: 16
 Conjuncts:    37
-Disjuncts:    25
+Disjuncts:    30
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/021.txtar
+++ b/cue/testdata/export/021.txtar
@@ -47,11 +47,11 @@ Leaks:  0
 Freed:  8
 Reused: 3
 Allocs: 5
-Retain: 2
+Retain: 10
 
 Unifications: 8
 Conjuncts:    14
-Disjuncts:    10
+Disjuncts:    18
 -- out/eval --
 (struct){
   b: (struct){

--- a/cue/testdata/export/025.txtar
+++ b/cue/testdata/export/025.txtar
@@ -45,11 +45,11 @@ Leaks:  5
 Freed:  6
 Reused: 2
 Allocs: 9
-Retain: 6
+Retain: 10
 
 Unifications: 9
 Conjuncts:    16
-Disjuncts:    12
+Disjuncts:    16
 -- out/eval --
 (struct){
   b: (_|_){

--- a/cue/testdata/export/issue854.txtar
+++ b/cue/testdata/export/issue854.txtar
@@ -28,10 +28,10 @@ Leaks:  4
 Freed:  2
 Reused: 0
 Allocs: 6
-Retain: 18
+Retain: 24
 
 Unifications: 6
-Conjuncts:    21
+Conjuncts:    27
 Disjuncts:    11
 -- out/eval --
 (struct){

--- a/cue/testdata/fulleval/004_field_comprehension.txtar
+++ b/cue/testdata/fulleval/004_field_comprehension.txtar
@@ -94,11 +94,11 @@ Leaks:  0
 Freed:  12
 Reused: 4
 Allocs: 8
-Retain: 5
+Retain: 16
 
 Unifications: 12
 Conjuncts:    20
-Disjuncts:    13
+Disjuncts:    16
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/010_field_comprehensions_with_multiple_keys.txtar
+++ b/cue/testdata/fulleval/010_field_comprehensions_with_multiple_keys.txtar
@@ -173,11 +173,11 @@ Leaks:  20
 Freed:  29
 Reused: 25
 Allocs: 24
-Retain: 20
+Retain: 62
 
 Unifications: 49
 Conjuncts:    48
-Disjuncts:    37
+Disjuncts:    67
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/016_struct_comprehension_with_template.txtar
+++ b/cue/testdata/fulleval/016_struct_comprehension_with_template.txtar
@@ -140,11 +140,11 @@ Leaks:  0
 Freed:  51
 Reused: 41
 Allocs: 10
-Retain: 4
+Retain: 7
 
 Unifications: 27
 Conjuncts:    70
-Disjuncts:    55
+Disjuncts:    58
 -- out/eval --
 (struct){
   result: (#list){

--- a/cue/testdata/fulleval/017_resolutions_in_struct_comprehension_keys.txtar
+++ b/cue/testdata/fulleval/017_resolutions_in_struct_comprehension_keys.txtar
@@ -35,7 +35,7 @@ Leaks:  2
 Freed:  3
 Reused: 0
 Allocs: 5
-Retain: 2
+Retain: 4
 
 Unifications: 5
 Conjuncts:    5

--- a/cue/testdata/fulleval/018_recursive_evaluation_within_list.txtar
+++ b/cue/testdata/fulleval/018_recursive_evaluation_within_list.txtar
@@ -63,11 +63,11 @@ Leaks:  0
 Freed:  21
 Reused: 14
 Allocs: 7
-Retain: 10
+Retain: 14
 
 Unifications: 21
 Conjuncts:    44
-Disjuncts:    27
+Disjuncts:    31
 -- out/eval --
 (struct){
   l: (#list){

--- a/cue/testdata/fulleval/020_complex_interaction_of_groundness.txtar
+++ b/cue/testdata/fulleval/020_complex_interaction_of_groundness.txtar
@@ -64,11 +64,11 @@ Leaks:  0
 Freed:  10
 Reused: 3
 Allocs: 7
-Retain: 3
+Retain: 7
 
 Unifications: 10
 Conjuncts:    33
-Disjuncts:    13
+Disjuncts:    17
 -- out/eval --
 (struct){
   res: (#list){

--- a/cue/testdata/fulleval/021_complex_groundness_2.txtar
+++ b/cue/testdata/fulleval/021_complex_groundness_2.txtar
@@ -74,11 +74,11 @@ Leaks:  0
 Freed:  16
 Reused: 8
 Allocs: 8
-Retain: 4
+Retain: 6
 
 Unifications: 16
 Conjuncts:    63
-Disjuncts:    20
+Disjuncts:    22
 -- out/eval --
 (struct){
   r1: (struct){

--- a/cue/testdata/fulleval/026_dont_convert_incomplete_errors_to_non-incomplete.txtar
+++ b/cue/testdata/fulleval/026_dont_convert_incomplete_errors_to_non-incomplete.txtar
@@ -49,11 +49,11 @@ Leaks:  0
 Freed:  17
 Reused: 12
 Allocs: 5
-Retain: 9
+Retain: 75
 
 Unifications: 17
-Conjuncts:    67
-Disjuncts:    20
+Conjuncts:    71
+Disjuncts:    82
 -- out/eval --
 (struct){
   n1: (struct){

--- a/cue/testdata/fulleval/031_comparison_against_bottom.txtar
+++ b/cue/testdata/fulleval/031_comparison_against_bottom.txtar
@@ -64,7 +64,7 @@ Leaks:  1
 Freed:  20
 Reused: 16
 Allocs: 5
-Retain: 2
+Retain: 5
 
 Unifications: 21
 Conjuncts:    30

--- a/cue/testdata/fulleval/042_cross-dependent_comprehension.txtar
+++ b/cue/testdata/fulleval/042_cross-dependent_comprehension.txtar
@@ -43,11 +43,11 @@ Leaks:  0
 Freed:  10
 Reused: 6
 Allocs: 4
-Retain: 3
+Retain: 4
 
 Unifications: 10
 Conjuncts:    20
-Disjuncts:    11
+Disjuncts:    12
 -- out/eval --
 (struct){
   #a: (_|_){

--- a/cue/testdata/fulleval/044_Issue_#178.txtar
+++ b/cue/testdata/fulleval/044_Issue_#178.txtar
@@ -29,11 +29,11 @@ Leaks:  0
 Freed:  5
 Reused: 2
 Allocs: 3
-Retain: 1
+Retain: 5
 
 Unifications: 5
 Conjuncts:    13
-Disjuncts:    6
+Disjuncts:    10
 -- out/eval --
 (struct){
   foo: (_|_){

--- a/cue/testdata/interpolation/041_interpolation.txtar
+++ b/cue/testdata/interpolation/041_interpolation.txtar
@@ -36,11 +36,11 @@ Leaks:  1
 Freed:  8
 Reused: 6
 Allocs: 3
-Retain: 8
+Retain: 12
 
 Unifications: 9
 Conjuncts:    17
-Disjuncts:    15
+Disjuncts:    19
 -- out/eval --
 Errors:
 e: invalid interpolation: cannot use [] (type list) as type (bool|string|bytes|number):

--- a/cue/testdata/lists/019_list_types.txtar
+++ b/cue/testdata/lists/019_list_types.txtar
@@ -121,11 +121,11 @@ Leaks:  15
 Freed:  26
 Reused: 23
 Allocs: 18
-Retain: 34
+Retain: 42
 
 Unifications: 41
 Conjuncts:    75
-Disjuncts:    59
+Disjuncts:    67
 -- out/eval --
 Errors:
 e0: incompatible list lengths (1 and 2)

--- a/cue/testdata/lists/020_list_arithmetic.txtar
+++ b/cue/testdata/lists/020_list_arithmetic.txtar
@@ -329,7 +329,7 @@ Leaks:  198
 Freed:  133
 Reused: 130
 Allocs: 201
-Retain: 300
+Retain: 390
 
 Unifications: 331
 Conjuncts:    475

--- a/cue/testdata/resolve/016_index.txtar
+++ b/cue/testdata/resolve/016_index.txtar
@@ -96,11 +96,11 @@ Leaks:  16
 Freed:  32
 Reused: 26
 Allocs: 22
-Retain: 18
+Retain: 23
 
 Unifications: 40
 Conjuncts:    61
-Disjuncts:    48
+Disjuncts:    53
 -- out/eval --
 Errors:
 c: invalid list index "3" (type string):

--- a/cue/testdata/resolve/038_incomplete_comprehensions.txtar
+++ b/cue/testdata/resolve/038_incomplete_comprehensions.txtar
@@ -52,11 +52,11 @@ Leaks:  0
 Freed:  11
 Reused: 5
 Allocs: 6
-Retain: 4
+Retain: 11
 
 Unifications: 11
 Conjuncts:    18
-Disjuncts:    13
+Disjuncts:    16
 -- out/eval --
 (struct){
   A: (_|_){

--- a/cue/testdata/resolve/047_struct_comprehensions.txtar
+++ b/cue/testdata/resolve/047_struct_comprehensions.txtar
@@ -82,7 +82,7 @@ Leaks:  2
 Freed:  11
 Reused: 5
 Allocs: 8
-Retain: 2
+Retain: 3
 
 Unifications: 9
 Conjuncts:    18

--- a/cue/testdata/resolve/048_builtins.txtar
+++ b/cue/testdata/resolve/048_builtins.txtar
@@ -84,7 +84,7 @@ Leaks:  6
 Freed:  61
 Reused: 53
 Allocs: 14
-Retain: 18
+Retain: 22
 
 Unifications: 55
 Conjuncts:    129

--- a/cue/testdata/scalars/embed.txtar
+++ b/cue/testdata/scalars/embed.txtar
@@ -155,11 +155,11 @@ Leaks:  11
 Freed:  120
 Reused: 113
 Allocs: 18
-Retain: 51
+Retain: 69
 
 Unifications: 127
 Conjuncts:    313
-Disjuncts:    157
+Disjuncts:    175
 -- out/eval --
 Errors:
 listEmbed.b6: invalid list index 5 (out of bounds):

--- a/internal/core/adt/context.go
+++ b/internal/core/adt/context.go
@@ -852,11 +852,18 @@ func (c *OpContext) lookup(x *Vertex, pos token.Pos, l Feature, state VertexStat
 
 	var hasCycle bool
 
-	if a != nil && state > a.status {
-		c.Unify(a, state)
-	}
-
-	if a == nil {
+	if a != nil {
+		// Ensure that a's status is at least of the required level. Otherwise,
+		// ensure that any remaining unprocessed conjuncts are processed by
+		// calling c.Unify(a, Partial). The ensures that need to rely on
+		// hasAllConjuncts, but that are finalized too early, get conjuncts
+		// processed beforehand.
+		if state > a.status {
+			c.Unify(a, state)
+		} else if a.state != nil {
+			c.Unify(a, Partial)
+		}
+	} else {
 		if x.state != nil {
 			for _, e := range x.state.exprs {
 				if isCyclePlaceholder(e.err) {

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -924,6 +924,15 @@ func (x *LetReference) resolve(ctx *OpContext, state VertexStatus) *Vertex {
 	//
 	//     In other words, a Vertex is not necessarily erroneous when a let
 	//     field contained in that Vertex is erroneous.
+
+	// TODO(order): Do not finalize? Although it is safe to finalize a let
+	// by itself, it is not necessarily safe, at this point, to finalize any
+	// references it makes. Originally, let finalization was requested to
+	// detect cases where multi-mode should be enabled. With the recent compiler
+	// changes, though, this should be detected statically. Leave this on for
+	// now, though, as it is not entirely clear it is fine to remove this.
+	// We can reevaluate this once we have redone some of the planned order of
+	// evaluation work.
 	ctx.Unify(arc, Finalized)
 	b, ok := arc.BaseValue.(*Bottom)
 	if !arc.MultiLet && !ok {


### PR DESCRIPTION
The current implementation finalizes vertices too
aggressively. This may result in conjuncts being
missed. The new notify mechanism may then end up
adding conjuncts to already-finalized vertices.

The fix for this is planned in v0.6. The current
implementation is already a lot more robust than
it way. However, although it problably fixes more
than that it breaks, it may break things that were
previously working.

This change more aggresively early evaluates
conjuncts to prevent them from being missed if a
node is in finalization mode. This fix most likely
will not cover all cases, but hopefully enough to
hold over until v0.6.

Fixes #2235

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Ia86e9efecde0225caf0d700bf797a3b2e6cfb2f1
