### PR TITLE
internal/ci: fix and test the release workflow on branches

### DIFF
--- a/.github/workflows/push_tip_to_trybot.yml
+++ b/.github/workflows/push_tip_to_trybot.yml
@@ -5,6 +5,7 @@ name: Push tip to trybot
   push:
     branches:
       - master
+      - release-branch.*
 concurrency: push_tip_to_trybot
 jobs:
   push:
@@ -32,5 +33,5 @@ jobs:
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
           git remote add origin https://review.gerrithub.io/a/cue-lang/cue
           git remote add trybot https://github.com/cue-lang/cue-trybot
-          git fetch origin master
-          git push trybot "refs/remotes/origin/*:refs/heads/*"
+          git fetch origin "${{ github.ref }}"
+          git push trybot "FETCH_HEAD:${{ github.ref }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ name: Release
   push:
     tags:
       - v*
+    branches:
+      - ci/test
+      - master
+      - release-branch.*
 concurrency: release
 jobs:
   goreleaser:
@@ -31,17 +35,21 @@ jobs:
           registry: docker.io
           username: cueckoo
           password: ${{ secrets.CUECKOO_DOCKER_PAT }}
+      - name: Install CUE
+        run: go install ./cmd/cue
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           install-only: true
           version: v1.13.1
-      - name: Run GoReleaser
+      - name: Run GoReleaser with CUE
         run: cue cmd release
         working-directory: ./internal/ci/goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.CUECKOO_GITHUB_PAT }}
-      - name: Re-test cuelang.org
+      - if: (github.ref == 'refs/tags/v*')
+        name: Re-test cuelang.org
         run: 'curl -f -s -H "Content-Type: application/json" -u cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} --request POST --data-binary "{\"event_type\":\"Re-test post release of ${GITHUB_REF##refs/tags/}\"}" https://api.github.com/repos/cue-lang/cuelang.org/dispatches'
-      - name: Trigger unity build
+      - if: (github.ref == 'refs/tags/v*')
+        name: Trigger unity build
         run: 'curl -f -s -H "Content-Type: application/json" -u cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} --request POST --data-binary "{\"event_type\":\"Check against CUE ${GITHUB_REF##refs/tags/}\",\"client_payload\":{\"type\":\"unity\",\"payload\":{\"versions\":\"\\\"${GITHUB_REF##refs/tags/}\\\"\"}}}" https://api.github.com/repos/cue-unity/unity/dispatches'

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -5,8 +5,9 @@ name: TryBot
   push:
     branches:
       - trybot/*/*
-      - master
       - ci/test
+      - master
+      - release-branch.*
     tags-ignore:
       - v*
   pull_request: {}
@@ -48,7 +49,7 @@ jobs:
             ${{ steps.go-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
-      - if: matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04'
+      - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
         name: Early git and code sanity checks
         run: |-
           # Ensure the recent commit messages have Signed-off-by headers.
@@ -65,23 +66,23 @@ jobs:
           		exit 1
           	fi
           done
-      - if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci/test'
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release-branch.*')
         run: echo CUE_LONG=true >> $GITHUB_ENV
-      - if: matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04'
+      - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
         name: Generate
         run: go generate ./...
-      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci/test') || !( matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04' )
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release-branch.*') || !(matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
         name: Test
         run: go test ./...
-      - if: matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04'
+      - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
         name: Test with -race
         run: go test -race ./...
-      - if: matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04'
+      - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
         name: Check
         run: go vet ./...
       - name: Check that git is clean at the end of the job
         run: test -z "$(git status --porcelain)" || (git status; git diff; false)
-      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci/test') && (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release-branch.*') && (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-20.04')
         name: Pull this commit through the proxy on master
         run: |-
           v=$(git rev-parse HEAD)

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -36,13 +36,6 @@ import (
 	"Code generated \(#generatedBy); DO NOT EDIT."
 }
 
-// #isDefaultBranch is an expression that evaluates to true if the
-// job is running as a result of pushing to the default branch, like master.
-// For the sake of testing CI, pushes to #testDefaultBranch branch also match.
-// It would be nice to use the "contains" builtin for simplicity,
-// but array literals are not yet supported in expressions.
-#isDefaultBranch: "github.ref == 'refs/heads/\(#defaultBranch)' || github.ref == 'refs/heads/\(#testDefaultBranch)'"
-
 #bashWorkflow: json.#Workflow & {
 	jobs: [string]: defaults: run: shell: "bash"
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -30,8 +30,9 @@ _#URLPath: {
 
 #goreleaserVersion: "v1.13.1"
 
-#defaultBranch:     "master"
-#releaseTagPattern: "v*"
+#defaultBranch:        "master"
+#releaseBranchPattern: "release-branch.*"
+#releaseTagPattern:    "v*"
 
 #codeReview: {
 	gerrit?:      string

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -15,19 +15,19 @@
 package github
 
 import (
-	"strings"
-
 	"cuelang.org/go/internal/ci/core"
 
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-// push_tip_to_trybot "syncs" active branches to the trybot repo
+// push_tip_to_trybot "syncs" active branches to the trybot repo.
+// Since the workflow is triggered by a push to any of the branches,
+// the step only needs to sync the pushed branch.
 push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {
-		push: branches: _#activeBranches
+		push: branches: _#protectedBranchPatterns
 	}
 
 	concurrency: "push_tip_to_trybot"
@@ -48,8 +48,8 @@ push_tip_to_trybot: _base.#bashWorkflow & {
 						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(_gerrithub.#botGitHubUser):${{ secrets.\(_gerrithub.#botGitHubUserTokenSecretsKey) }} | base64)"
 						git remote add origin \(_gerrithub.#gerritHubRepository)
 						git remote add trybot \(_gerrithub.#trybotRepositoryURL)
-						git fetch origin \(strings.Join(_#activeBranches, " "))
-						git push trybot "refs/remotes/origin/*:refs/heads/*"
+						git fetch origin "${{ github.ref }}"
+						git push trybot "FETCH_HEAD:${{ github.ref }}"
 						"""
 			},
 		]

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -15,6 +15,8 @@
 package github
 
 import (
+	"list"
+
 	"cuelang.org/go/internal/ci/core"
 
 	"github.com/SchemaStore/schemastore/src/schemas/json"
@@ -33,7 +35,7 @@ trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: ["trybot/*/*", core.#defaultBranch, _base.#testDefaultBranch] // do not run PR branches
+			branches: list.Concat([["trybot/*/*", _base.#testDefaultBranch], _#protectedBranchPatterns]) // do not run PR branches
 			"tags-ignore": [core.#releaseTagPattern]
 		}
 		pull_request: {}
@@ -60,18 +62,18 @@ trybot: _base.#bashWorkflow & {
 				_base.#earlyChecks & {
 					// These checks don't vary based on the Go version or OS,
 					// so we only need to run them on one of the matrix jobs.
-					if: "\(#_isLatestLinux)"
+					if: _#isLatestLinux
 				},
 				json.#step & {
-					if:  "\(_base.#isDefaultBranch)"
+					if:  _#isProtectedBranch
 					run: "echo CUE_LONG=true >> $GITHUB_ENV"
 				},
 				_#goGenerate,
 				_#goTest & {
-					if: "(\(_base.#isDefaultBranch)) || !( \(#_isLatestLinux) )"
+					if: "\(_#isProtectedBranch) || !\(_#isLatestLinux)"
 				},
 				_#goTestRace & {
-					if: "\(#_isLatestLinux)"
+					if: _#isLatestLinux
 				},
 				_#goCheck,
 				_base.#checkGitClean,
@@ -114,7 +116,7 @@ trybot: _base.#bashWorkflow & {
 			echo "giving up after a number of retries"
 			exit 1
 			"""
-		if: "(\(_base.#isDefaultBranch)) && (\(#_isLatestLinux))"
+		if: "\(_#isProtectedBranch) && \(_#isLatestLinux)"
 	}
 
 	_#goGenerate: json.#step & {
@@ -122,7 +124,7 @@ trybot: _base.#bashWorkflow & {
 		run:  "go generate ./..."
 		// The Go version corresponds to the precise version specified in
 		// the matrix. Skip windows for now until we work out why re-gen is flaky
-		if: "\(#_isLatestLinux)"
+		if: _#isLatestLinux
 	}
 
 	_#goTest: json.#step & {
@@ -137,7 +139,7 @@ trybot: _base.#bashWorkflow & {
 		// dependencies that vary wildly between platforms.
 		// For now, to save CI resources, just run the checks on one matrix job.
 		// TODO: consider adding more checks as per https://github.com/golang/go/issues/42119.
-		if:   "\(#_isLatestLinux)"
+		if:   "\(_#isLatestLinux)"
 		name: "Check"
 		run:  "go vet ./..."
 	}

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -55,16 +55,31 @@ workflows: [
 	},
 ]
 
-_#activeBranches: [core.#defaultBranch]
+// _#protectedBranchPatterns is a list of glob patterns to match the protected
+// git branches which are continuously used during development on Gerrit.
+// This includes the default branch and release branches,
+// but excludes any others like feature branches or short-lived branches.
+// Note that #testDefaultBranch is excluded as it is GitHub-only.
+_#protectedBranchPatterns: [core.#defaultBranch, core.#releaseBranchPattern]
+
+// _#isProtectedBranch is an expression that evaluates to true if the
+// job is running as a result of pushing to one of _#protectedBranchPatterns.
+// It would be nice to use the "contains" builtin for simplicity,
+// but array literals are not yet supported in expressions.
+_#isProtectedBranch: "(" + strings.Join([ for branch in _#protectedBranchPatterns {
+	"github.ref == 'refs/heads/\(branch)'"
+}], " || ") + ")"
+
+_#isReleaseTag: "(github.ref == 'refs/tags/\(core.#releaseTagPattern)')"
 
 _#linuxMachine:   "ubuntu-20.04"
 _#macosMachine:   "macos-11"
 _#windowsMachine: "windows-2022"
 
-// #_isLatestLinux evaluates to true if the job is running on Linux with the
+// _#isLatestLinux evaluates to true if the job is running on Linux with the
 // latest version of Go. This expression is often used to run certain steps
 // just once per CI workflow, to avoid duplicated work.
-#_isLatestLinux: "matrix.go-version == '\(core.#latestStableGo)' && matrix.os == '\(_#linuxMachine)'"
+_#isLatestLinux: "(matrix.go-version == '\(core.#latestStableGo)' && matrix.os == '\(_#linuxMachine)')"
 
 _#testStrategy: {
 	"fail-fast": false

--- a/internal/ci/goreleaser/goreleaser_tool.cue
+++ b/internal/ci/goreleaser/goreleaser_tool.cue
@@ -16,11 +16,13 @@ command: release: {
 
 	let _env = env
 
-	let _githubActions = env.GITHUB_ACTIONS | "" // "true" if running in CI
-	let _githubRef = path.Base(env.GITHUB_REF | "refs/tags/<not a github release>")
+	let _githubRef = env.GITHUB_REF | "refs/no_ref_kind/not_a_release" // filled when running in CI
+	let _githubRefName = path.Base(_githubRef)
 
-	// Only run the full release as part of GitHub actions
-	let snapshot = [ if _githubActions != "true" {"--snapshot"}, ""][0]
+	// Only run the full release when running on GitHub actions for a release tag.
+	// Keep in sync with core.#releaseTagPattern, which is a globbing pattern
+	// rather than a regular expression.
+	let snapshot = [ if _githubRef !~ "refs/tags/v.*" {"--snapshot"}, "" ][0]
 
 	tempDir: file.MkdirTemp & {
 		path: string
@@ -59,7 +61,8 @@ command: release: {
 		text: """
 			snapshot: \(snapshot)
 			latest CUE version: \(latestCUEVersion)
-			release version: \(_githubRef)
+			git ref: \(_githubRef)
+			release name: \(_githubRefName)
 			"""
 	}
 
@@ -68,7 +71,7 @@ command: release: {
 
 		// Set the goreleaser configuration to be stdin
 		stdin: yaml.Marshal(config & {
-			#latest: path.Base(_githubRef) == strings.TrimSpace(latestCUE.stdout)
+			#latest: _githubRefName == strings.TrimSpace(latestCUE.stdout)
 		})
 
 		// Run at the root of the module


### PR DESCRIPTION
https://cuelang.org/cl/546920 switched to running goreleaser via CUE,
so that we can customize the configuration with CUE as a first step.
By the point we run "cue cmd release" on CI, both Go and goreleaser are
installed, but CUE itself is not. Install it.

Teach CI to run goreleaser in "snapshot" mode when not doing a release,
so that we can continuously test that our integration with goreleaser
isn't broken by running it on branches like master and ci/test.

Update the list of branches to also match release branches,
and change "is default branch" in favor of "is active branch",
since we also want to run the long tests and release checks there.

Finally, per Paul's suggestion, change all isX definitions to include
surrounding parentheses, so that we can always use them with operators
like && or || without having to remember to add them later.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I4e5f00abac4d87fbca2bcd27c4ddb24b4aaee6d4
