### PR TITLE
encoding/protobuf/jsonpb: remove unused code

### DIFF
--- a/encoding/protobuf/jsonpb/encoder.go
+++ b/encoding/protobuf/jsonpb/encoder.go
@@ -80,16 +80,6 @@ type encoder struct {
 	errs errors.Error
 }
 
-func (e *encoder) addErr(err errors.Error) {
-	e.errs = errors.Append(e.errs, err)
-}
-
-func (e *encoder) addErrf(p token.Pos, schema cue.Value, format string, args ...interface{}) {
-	format = "%s: " + format
-	args = append([]interface{}{schema.Path()}, args...)
-	e.addErr(errors.Newf(p, format, args...))
-}
-
 func (e *encoder) rewriteDecls(schema cue.Value, decls []ast.Decl) {
 	for _, f := range decls {
 		field, ok := f.(*ast.Field)


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: Ie025fe5557ecac15459c034c3d0876818554d166
