### PR TITLE
encoding/protobuf: remove unused code

### DIFF
--- a/encoding/protobuf/util.go
+++ b/encoding/protobuf/util.go
@@ -41,7 +41,6 @@ type protoError struct {
 }
 
 var (
-	newline    = token.Newline.Pos()
 	newSection = token.NewSection.Pos()
 )
 


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I4b2df1c3b2dd6d6dc521ca3116e19fd3fab6a71e
