### PR TITLE
pkg/path: remove unused code

### DIFF
--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -494,38 +494,6 @@ func TestIsAbs(t *testing.T) {
 	}
 }
 
-// // simpleJoin builds a file name from the directory and path.
-// // It does not use Join because we don't want ".." to be evaluated.
-// func simpleJoin(dir, path string) string {
-// 	return dir + string(Separator) + path
-// }
-
-// Test directories relative to temporary directory.
-// The tests are run in absTestDirs[0].
-var absTestDirs = []string{
-	"a",
-	"a/b",
-	"a/b/c",
-}
-
-// Test paths relative to temporary directory. $ expands to the directory.
-// The tests are run in absTestDirs[0].
-// We create absTestDirs first.
-var absTests = []string{
-	".",
-	"b",
-	"b/",
-	"../a",
-	"../a/b",
-	"../a/b/./c/../../.././a",
-	"../a/b/./c/../../.././a/",
-	"$",
-	"$/.",
-	"$/a/../a/b",
-	"$/a/b/c/../../.././a",
-	"$/a/b/c/../../.././a/",
-}
-
 type RelTests struct {
 	root, path, want string
 }


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I9f0492b476b44de4fc30dc100c44896f3dbe0f9c
