### PR TITLE
internal/core/compile: remove unused code

### DIFF
--- a/internal/core/compile/builtin.go
+++ b/internal/core/compile/builtin.go
@@ -24,7 +24,6 @@ import (
 const supportedByLen = adt.StructKind | adt.BytesKind | adt.StringKind | adt.ListKind
 
 var (
-	stringParam = adt.Param{Value: &adt.BasicType{K: adt.StringKind}}
 	structParam = adt.Param{Value: &adt.BasicType{K: adt.StructKind}}
 	listParam   = adt.Param{Value: &adt.BasicType{K: adt.ListKind}}
 	intParam    = adt.Param{Value: &adt.BasicType{K: adt.IntKind}}

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -123,12 +123,6 @@ type compiler struct {
 	errs errors.Error
 }
 
-func (c *compiler) reset() {
-	c.fileScope = nil
-	c.stack = c.stack[:0]
-	c.errs = nil
-}
-
 func (c *compiler) errf(n ast.Node, format string, args ...interface{}) *adt.Bottom {
 	err := &compilerError{
 		n:       n,


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I67606b15f9e31bcc9b37d8225175a9dc7e690c64
