### PR TITLE
internal/diff: remove unused code

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -16,7 +16,6 @@ package diff
 
 import (
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/errors"
 )
 
 // Profile configures a diff operation.
@@ -165,9 +164,7 @@ func (e Edit) XPos() int  { return int(e.xPos - 1) }
 func (e Edit) YPos() int  { return int(e.yPos - 1) }
 
 type differ struct {
-	cfg     Profile
-	options []cue.Option
-	errs    errors.Error
+	cfg Profile
 }
 
 func (d *differ) diffValue(x, y cue.Value) (Kind, *EditScript) {

--- a/internal/diff/print.go
+++ b/internal/diff/print.go
@@ -75,14 +75,6 @@ func (p *printer) Write(b []byte) (n int, err error) {
 	return len(b), nil
 }
 
-func (p *printer) write(b []byte) {
-	_, _ = p.Write(b)
-}
-
-func (p *printer) printLen(align int, str string) {
-	fmt.Fprintf(p, "% -[1]*s", align, str)
-}
-
 func (p *printer) println(s string) {
 	fmt.Fprintln(p, s)
 }


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: Id9f42d6ba8f77c9098986a2e72f041f86f0db05b
