### PR TITLE
encoding/jsonschema: remove unused code

### DIFF
--- a/encoding/jsonschema/decode.go
+++ b/encoding/jsonschema/decode.go
@@ -198,10 +198,6 @@ func (d *decoder) uint(n cue.Value) ast.Expr {
 	return n.Syntax(cue.Final()).(ast.Expr)
 }
 
-func (d *decoder) bool(n cue.Value) ast.Expr {
-	return n.Syntax(cue.Final()).(ast.Expr)
-}
-
 func (d *decoder) boolValue(n cue.Value) bool {
 	x, err := n.Bool()
 	if err != nil {


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I0292be1fb0b2e35ad5a59732a19bec9ef78cae5f
