### PR TITLE
internal/core/export: remove unused code

### DIFF
--- a/internal/core/export/export.go
+++ b/internal/core/export/export.go
@@ -248,8 +248,6 @@ type exporter struct {
 	valueAlias  map[*ast.Alias]*ast.Alias
 	letAlias    map[*ast.LetClause]*ast.LetClause
 
-	usedHidden map[string]bool
-
 	pivotter *pivotter
 }
 
@@ -651,20 +649,4 @@ func (e *exporter) setDocs(x adt.Node) {
 	f := e.stack[len(e.stack)-1]
 	f.docSources = []adt.Conjunct{adt.MakeRootConjunct(nil, x)}
 	e.stack[len(e.stack)-1] = f
-}
-
-// func (e *Exporter) promise(upCount int32, f completeFunc) {
-// 	e.todo = append(e.todo, f)
-// }
-
-func (e *exporter) errf(format string, args ...interface{}) *ast.BottomLit {
-	err := &exporterError{}
-	e.errs = errors.Append(e.errs, err)
-	return &ast.BottomLit{}
-}
-
-type errTODO errors.Error
-
-type exporterError struct {
-	errTODO
 }

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -338,7 +338,6 @@ func (c *conjuncts) addConjunct(f adt.Feature, env *adt.Environment, n adt.Node)
 }
 
 type field struct {
-	docs      []*ast.CommentGroup
 	arc       *adt.Vertex
 	conjuncts []conjunct
 }

--- a/internal/core/export/self.go
+++ b/internal/core/export/self.go
@@ -110,7 +110,6 @@ func (d *depData) usageCount() int {
 
 type refData struct {
 	dst *depData
-	ref ast.Expr
 }
 
 func (v *depData) node() *adt.Vertex {

--- a/internal/core/export/toposort.go
+++ b/internal/core/export/toposort.go
@@ -51,40 +51,6 @@ func VertexFeatures(c *adt.OpContext, v *adt.Vertex) []adt.Feature {
 	return a
 }
 
-// func structFeatures(a []*adt.StructLit) []adt.Feature {
-// 	sets := extractFeatures(a)
-// 	return sortedArcs(sets)
-// }
-
-func (e *exporter) sortedArcs(v *adt.Vertex) (sorted []*adt.Vertex) {
-	if adt.DebugSort > 0 {
-		return v.Arcs
-	}
-
-	a := extractFeatures(v.Structs)
-	if len(a) == 0 {
-		return v.Arcs
-	}
-
-	sorted = make([]*adt.Vertex, len(v.Arcs))
-	copy(sorted, v.Arcs)
-
-	m := sortArcs(a)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		if m[sorted[i].Label] == 0 {
-			return m[sorted[j].Label] != 0
-		}
-		return m[sorted[i].Label] > m[sorted[j].Label]
-	})
-
-	return sorted
-}
-
-// TODO: remove
-func (e *exporter) extractFeatures(in []*adt.StructInfo) (a [][]adt.Feature) {
-	return extractFeatures(in)
-}
-
 func extractFeatures(in []*adt.StructInfo) (a [][]adt.Feature) {
 	for _, s := range in {
 		sorted := []adt.Feature{}


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: Ic2e80a5243da14af6548cab4fd7554e464d5a92a
