### PR TITLE
internal/encoding: remove unused code

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -464,21 +464,3 @@ func (v *validator) validate(n ast.Node) bool {
 	}
 	return ok
 }
-
-// simplify reformats a File. To be used as a wrapper for Extract functions.
-//
-// It currently does so by formatting the file using fmt.Format and then
-// reparsing it. This is not ideal, but the package format does not provide a
-// way to do so differently.
-func simplify(f *ast.File, err error) (*ast.File, error) {
-	if err != nil {
-		return nil, err
-	}
-	// This needs to be a function that modifies f in order to maintain line
-	// number information.
-	b, err := format.Node(f, format.Simplify())
-	if err != nil {
-		return nil, err
-	}
-	return parser.ParseFile(f.Filename, b, parser.ParseComments)
-}


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I398eaf4e3a5233123bfa947803d53485008d0b99
