### PR TITLE
internal/core/adt: remove unused code

### DIFF
--- a/internal/core/adt/errors.go
+++ b/internal/core/adt/errors.go
@@ -128,17 +128,6 @@ func isError(v Value) bool {
 	return ok
 }
 
-// isIncomplete reports whether v is associated with an incomplete error.
-func isIncomplete(v *Vertex) bool {
-	if v == nil {
-		return true
-	}
-	if b, ok := v.BaseValue.(*Bottom); ok {
-		return b.IsIncomplete()
-	}
-	return false
-}
-
 // AddChildError updates x to record an error that occurred in one of
 // its descendent arcs. The resulting error will record the worst error code of
 // the current error or recursive error.

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -46,16 +46,6 @@ func (c *OpContext) Stats() *stats.Counts {
 	return &c.stats
 }
 
-// TODO: Note: NewContext takes essentially a cue.Value. By making this
-// type more central, we can perhaps avoid context creation.
-
-// func NewContext(r Runtime, v *Vertex) *OpContext {
-// 	e := NewUnifier(r)
-// 	return e.NewContext(v)
-// }
-
-var structSentinel = &StructMarker{}
-
 var incompleteSentinel = &Bottom{
 	Code: IncompleteError,
 	Err:  errors.Newf(token.NoPos, "incomplete"),
@@ -1398,7 +1388,6 @@ type envList struct {
 	id      CloseInfo
 	ignore  bool // has a self-referencing comprehension and is postponed
 	self    bool // was added as a postponed self-referencing comprehension
-	index   int
 }
 
 type envCheck struct {
@@ -1662,28 +1651,6 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 		c.CloseInfo = closeInfo
 		n.addExprConjunct(c, Partial)
 	}
-}
-
-// isDef reports whether an expressions is a reference that references a
-// definition anywhere in its selection path.
-//
-// TODO(performance): this should be merged with resolve(). But for now keeping
-// this code isolated makes it easier to see what it is for.
-func isDef(x Expr) bool {
-	switch r := x.(type) {
-	case *FieldReference:
-		return r.Label.IsDef()
-
-	case *SelectorExpr:
-		if r.Sel.IsDef() {
-			return true
-		}
-		return isDef(r.X)
-
-	case *IndexExpr:
-		return isDef(r.X)
-	}
-	return false
 }
 
 func (n *nodeContext) addValueConjunct(env *Environment, v Value, id CloseInfo) {


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I3e44eaf1d2671a8f8a34a635aae54ea59ce32160
