### PR TITLE
tools/fix: remove unused code

### DIFF
--- a/tools/fix/fix.go
+++ b/tools/fix/fix.go
@@ -30,8 +30,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	simplify   bool
-	deprecated bool
+	simplify bool
 }
 
 // Simplify enables fixes that simplify the code, but are not strictly


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I576f48e4bbdd4780b05dd1f07582c5b966f16856
