### PR TITLE
encoding/openapi: remove unused code

### DIFF
--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -44,7 +44,6 @@ type buildContext struct {
 	nameFunc      func(inst cue.Value, path cue.Path) string
 	descFunc      func(v cue.Value) string
 	fieldFilter   *regexp.Regexp
-	evalDepth     int // detect cycles when resolving references
 
 	schemas *OrderedMap
 
@@ -517,28 +516,6 @@ outer:
 		}
 	}
 	return a
-}
-
-func countNodes(v cue.Value) (n int) {
-	switch op, a := v.Expr(); op {
-	case cue.OrOp, cue.AndOp:
-		for _, v := range a {
-			n += countNodes(v)
-		}
-		n += len(a) - 1
-	default:
-		switch v.Kind() {
-		case cue.ListKind:
-			for i, _ := v.List(); i.Next(); {
-				n += countNodes(i.Value())
-			}
-		case cue.StructKind:
-			for i, _ := v.Fields(); i.Next(); {
-				n += countNodes(i.Value()) + 1
-			}
-		}
-	}
-	return n + 1
 }
 
 // isConcrete reports whether v is concrete and not a struct (recursively).


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I7a2ee05fcc8a36140e07bea8162f97d0854e26ec
