### PR TITLE
cmd/cue/cmd: remove unused code

### DIFF
--- a/cmd/cue/cmd/flags.go
+++ b/cmd/cue/cmd/flags.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -110,24 +109,5 @@ func (f flagName) String(cmd *Command) string {
 
 func (f flagName) StringArray(cmd *Command) []string {
 	v, _ := cmd.Flags().GetStringArray(string(f))
-	return v
-}
-
-type stringFlag struct {
-	name  string
-	short string
-	text  string
-	def   string
-}
-
-func (f *stringFlag) Add(cmd *cobra.Command) {
-	cmd.Flags().StringP(f.name, f.short, f.def, f.text)
-}
-
-func (f *stringFlag) String(cmd *Command) string {
-	v, err := cmd.Flags().GetString(f.name)
-	if err != nil {
-		return f.def
-	}
 	return v
 }


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I00923f428cd24def15907946c58202a58a9f1cdc
