### PR TITLE
pkg/internal: remove unused code

### DIFF
--- a/pkg/internal/builtin.go
+++ b/pkg/internal/builtin.go
@@ -189,10 +189,6 @@ func (x *Builtin) name(ctx *adt.OpContext) string {
 	return fmt.Sprintf("%s.%s", x.Pkg.StringValue(ctx), x.Name)
 }
 
-func (x *Builtin) isValidator() bool {
-	return len(x.Params) == 1 && x.Result == adt.BoolKind
-}
-
 func processErr(call *CallCtxt, errVal interface{}, ret adt.Expr) adt.Expr {
 	ctx := call.ctx
 	switch err := errVal.(type) {


### PR DESCRIPTION
When refactoring cue/load, I noticed that some pieces of code
were unused, which makes it less obvious what kinds of things
can be done. I used `staticcheck` to point out many other
places in the code that are unused.

This is one of those places.  I feel it's better to remove this code
even if it might be used in the future (it's always there to be found
in the git history).

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I8f3c60f7e8d05476bc8d1db5b2ef8bb4d9e9fb69
