### PR TITLE
cmd/cue: include Go in the version command

### DIFF
--- a/cmd/cue/cmd/testdata/script/version.txtar
+++ b/cmd/cue/cmd/testdata/script/version.txtar
@@ -8,8 +8,9 @@ stdout -count=1 'cue version \(devel\)'
 # Version output with VCS information.
 env CUE_VERSION_TEST_CFG='[{"Key":"vcs","Value":"git"},{"Key":"vcs.revision","Value":"47b7032385cb490fab7d47b89fca36835cf13d39"},{"Key":"vcs.time","Value":"2022-05-10T04:58:46Z"},{"Key":"vcs.modified","Value":"true"}]'
 exec cue version
-[!go1.18] stdout -count=1 'cue version \(devel\) [a-z]+/[a-z]+'
-[go1.18] stdout -count=1 'cue version v0.0.0-20220510045846-47b7032385cb$'
+[!go1.18] stdout -count=1 '^cue version \(devel\) [a-z]+/[a-z]+'
+[go1.18] stdout -count=1 '^cue version v0.0.0-20220510045846-47b7032385cb$'
+[go1.18] stdout -count=1 '^go version (devel )?go1.'
 [go1.18] stdout -count=1 'vcs git'
 [go1.18] stdout -count=1 'vcs\.revision 47b7032385cb490fab7d47b89fca36835cf13d39'
 [go1.18] stdout -count=1 'vcs\.time 2022-05-10T04:58:46Z'

--- a/cmd/cue/cmd/version_1.18.go
+++ b/cmd/cue/cmd/version_1.18.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"time"
 
@@ -77,7 +78,8 @@ func runVersion(cmd *Command, args []string) error {
 		}
 	}
 
-	fmt.Fprintf(w, "cue version %v\n\n", version)
+	fmt.Fprintf(w, "cue version %s\n\n", version)
+	fmt.Fprintf(w, "go version %s\n", runtime.Version())
 	for _, s := range bi.Settings {
 		if s.Value == "" {
 			// skip empty build settings


### PR DESCRIPTION
We were showing CUE's own module version,
plus all the settings used for its Go build,
but we entirely forgot to include the version of Go used.

For example, a CUE tip build with Go tip now reports:

	$ cue version
	cue version v0.0.0-20230202102539-2293f18bafde

	go version devel go1.21-6d4de4e386 Wed Feb 1 21:31:01 2023 +0000
		  -buildmode exe
		   -compiler gc
		 CGO_ENABLED 1
			  GOARCH amd64
				GOOS linux
			 GOAMD64 v3
				 vcs git
		vcs.revision 2293f18bafde366df4171c78bd6e7029b53429e0
			vcs.time 2023-02-02T10:25:39Z
		vcs.modified false

I chose to put the new line next to the build settings,
as they both relate to how "go build" was run.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: Id6f28ed4a011404a1b87b49b53dc1ad36cd86338
