### PR TITLE
internal/ci: do not release "zero" releases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: Release
   push:
     tags:
       - v*
+      - '!*-0.dev'
     branches:
       - ci/test
       - master

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -30,9 +30,39 @@ _#URLPath: {
 
 #goreleaserVersion: "v1.13.1"
 
-#defaultBranch:        "master"
-#releaseBranchPattern: "release-branch.*"
-#releaseTagPattern:    "v*"
+#defaultBranch: "master"
+
+// #releaseBranchPrefix is the git branch name prefix used to identify
+// release branches.
+#releaseBranchPrefix: "release-branch."
+
+// #releaseBranchPattern is the GitHub pattern that corresponds to
+// #releaseBranchPrefix.
+#releaseBranchPattern: #releaseBranchPrefix + "*"
+
+// #releaseTagPrefix is the prefix used to identify all git tag that correspond
+// to semver releases
+#releaseTagPrefix: "v"
+
+// #releaseTagPattern is the GitHub glob pattern that corresponds to
+// #releaseTagPrefix.
+#releaseTagPattern: #releaseTagPrefix + "*"
+
+// #zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
+// When we create a release branch for v0.$X.0, it's likely that commits on the
+// default branch will from that point onwards be intended for the $X+1
+// version. However, unless we tag the next commit after the release branch, it
+// might be the case that pseudo versions of those later commits refer to the
+// $X release.
+//
+// A "zero" tag fixes this when applied to the first commit after a release
+// branch. Critically, the -0.dev pre-release suffix is ordered before -alpha.
+// tags.
+#zeroReleaseTagSuffix: "-0.dev"
+
+// #zeroReleaseTagPattern is the GitHub glob pattern that corresponds
+// #zeroReleaseTagSuffix.
+#zeroReleaseTagPattern: "*" + #zeroReleaseTagSuffix
 
 #codeReview: {
 	gerrit?:      string

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -37,7 +37,7 @@ release: _base.#bashWorkflow & {
 	concurrency: "release"
 
 	on: push: {
-		tags: [core.#releaseTagPattern]
+		tags: [core.#releaseTagPattern, "!" + core.#zeroReleaseTagPattern]
 		branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
 	}
 	jobs: goreleaser: {

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -68,9 +68,9 @@ _#protectedBranchPatterns: [core.#defaultBranch, core.#releaseBranchPattern]
 // See https://docs.github.com/en/actions/learn-github-actions/expressions.
 _#matchPattern: {
 	variable: string
-	pattern: string
-	expr: [
-		if strings.HasSuffix(pattern, "*") {
+	pattern:  string
+	expr:     [
+			if strings.HasSuffix(pattern, "*") {
 			let prefix = strings.TrimSuffix(pattern, "*")
 			"startsWith(\(variable), '\(prefix)')"
 		},

--- a/internal/ci/goreleaser/goreleaser_tool.cue
+++ b/internal/ci/goreleaser/goreleaser_tool.cue
@@ -9,6 +9,8 @@ import (
 	"tool/exec"
 	"tool/os"
 	"tool/cli"
+
+	"cuelang.org/go/internal/ci/core"
 )
 
 command: release: {
@@ -58,7 +60,7 @@ command: release: {
 		// Only run the full release when running on GitHub actions for a release tag.
 		// Keep in sync with core.#releaseTagPattern, which is a globbing pattern
 		// rather than a regular expression.
-		if _githubRef !~ "refs/tags/v.*" {
+		if _githubRef !~ "refs/tags/\(core.#releaseTagPrefix).*" {
 			"--snapshot"
 		},
 	]


### PR DESCRIPTION
When we create a release branch for v0.$X.0, it's likely that commits on
the default branch will from that point onwards be intended for the $X+1
version. However, unless we tag the next commit after the release
branch, it might be the case that pseudo versions of those later commits
refer to the $X release.

A "zero" tag fixes this when applied to the first commit after a release
branch. Critically, the -0.dev pre-release suffix is ordered before
-alpha tags.

This is per advice in:

https://github.com/golang/go/issues/38985#issuecomment-626925765

Also DRY up our use of tag prefixes (and suffixes) so that they can be
reused in GitHub glob patterns as well as CUE regular expressions.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I79b9308fd858cb1e08f119787254f5927e503545
