### PR TITLE
trybot/I50032f9e9ff8cd0236c24c10b25cadbf84e42ca5/eeba246fb5e56a410c5e8f52541d2ee4a7266c15/549385/1

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -96,7 +96,7 @@ jobs:
           	# avoid stopping too early. We also use a "failed" file as "go get" runs
           	# in a subshell via the pipe.
           	rm -f failed
-          	if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go/cmd/cue@$v; then
+          	if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go@$v; then
           		touch failed
           	fi |& tee output.txt
 

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -97,7 +97,7 @@ trybot: _base.#bashWorkflow & {
 				# avoid stopping too early. We also use a "failed" file as "go get" runs
 				# in a subshell via the pipe.
 				rm -f failed
-				if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go/cmd/cue@$v; then
+				if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go@$v; then
 					touch failed
 				fi |& tee output.txt
 

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -67,15 +67,15 @@ _#protectedBranchPatterns: [core.#defaultBranch, core.#releaseBranchPattern]
 // and for suffix patterns it uses "startsWith".
 // See https://docs.github.com/en/actions/learn-github-actions/expressions.
 _#matchPattern: {
-	variable: string
-	pattern:  string
-	expr:     [
-			if strings.HasSuffix(pattern, "*") {
-			let prefix = strings.TrimSuffix(pattern, "*")
-			"startsWith(\(variable), '\(prefix)')"
+	#variable: string
+	#pattern:  string
+	[
+		if strings.HasSuffix(#pattern, "*") {
+			let prefix = strings.TrimSuffix(#pattern, "*")
+			"startsWith(\(#variable), '\(prefix)')"
 		},
 		{
-			"\(variable) == '\(pattern)'"
+			"\(#variable) == '\(#pattern)'"
 		},
 	][0]
 }
@@ -85,10 +85,10 @@ _#matchPattern: {
 // It would be nice to use the "contains" builtin for simplicity,
 // but array literals are not yet supported in expressions.
 _#isProtectedBranch: "(" + strings.Join([ for branch in _#protectedBranchPatterns {
-	(_#matchPattern & {variable: "github.ref", pattern: "refs/heads/\(branch)"}).expr
+	_#matchPattern & {#variable: "github.ref", #pattern: "refs/heads/\(branch)", _}
 }], " || ") + ")"
 
-_#isReleaseTag: (_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(core.#releaseTagPattern)"}).expr
+_#isReleaseTag: _#matchPattern & {#variable: "github.ref", #pattern: "refs/tags/\(core.#releaseTagPattern)", _}
 
 _#linuxMachine:   "ubuntu-20.04"
 _#macosMachine:   "macos-11"


### PR DESCRIPTION
- internal/ci: use simpler "go get" to pull a version through the proxy
- internal/ci: embed the resulting string in _#matchPattern
