### PR TITLE
internal/ci: use simpler "go get" to pull a version through the proxy

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -96,7 +96,7 @@ jobs:
           	# avoid stopping too early. We also use a "failed" file as "go get" runs
           	# in a subshell via the pipe.
           	rm -f failed
-          	if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go/cmd/cue@$v; then
+          	if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go@$v; then
           		touch failed
           	fi |& tee output.txt
 

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -97,7 +97,7 @@ trybot: _base.#bashWorkflow & {
 				# avoid stopping too early. We also use a "failed" file as "go get" runs
 				# in a subshell via the pipe.
 				rm -f failed
-				if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go/cmd/cue@$v; then
+				if ! GOPROXY=https://proxy.golang.org go get cuelang.org/go@$v; then
 					touch failed
 				fi |& tee output.txt
 


### PR DESCRIPTION
Sometimes, proxy.golang.org flakes with a confusing error:

	server response: not found: cuelang.org/go/cmd/cue@v0.0.0-20230202153442-63749fe7d1fc:
		invalid version: missing cuelang.org/go/cmd/cue/go.mod at revision 63749fe7d1fc

The error is not our fault, and it looks like some sort of race or
temporary problem on the proxy's side.

It is interesting that it tries to locate a go.mod file inside cmd/cue.
We only need to pull the module through the proxy, not a package,
so doing just that is simpler and may make this edge case failure
less likely to happen in practice.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I18759da21d45f25dc65049cac4c691ea0f9d38b0
