### PR TITLE
cue/ast: fix IsValidIdent for _0

### DIFF
--- a/cue/ast/ident.go
+++ b/cue/ast/ident.go
@@ -40,24 +40,25 @@ func IsValidIdent(ident string) bool {
 	}
 
 	// TODO: use consumed again to allow #0.
-	// consumed := false
+	consumed := false
 	if strings.HasPrefix(ident, "_") {
 		ident = ident[1:]
-		// consumed = true
+		consumed = true
 		if len(ident) == 0 {
 			return true
 		}
 	}
 	if strings.HasPrefix(ident, "#") {
 		ident = ident[1:]
-		// consumed = true
+		// Note: _#0 is not allowed by the spec, although _0 is.
+		consumed = false
 	}
 
-	// if !consumed {
-	if r, _ := utf8.DecodeRuneInString(ident); isDigit(r) {
-		return false
+	if !consumed {
+		if r, _ := utf8.DecodeRuneInString(ident); isDigit(r) {
+			return false
+		}
 	}
-	// }
 
 	for _, r := range ident {
 		if isLetter(r) || isDigit(r) || r == '_' || r == '$' {

--- a/cue/ast/ident_test.go
+++ b/cue/ast/ident_test.go
@@ -73,6 +73,14 @@ func TestLabelName(t *testing.T) {
 		out:     "_",
 		isIdent: true,
 	}, {
+		in:      &ast.Ident{Name: "_1"},
+		out:     "_1",
+		isIdent: true,
+	}, {
+		in:  &ast.Ident{Name: "_#1"},
+		out: "",
+		err: true,
+	}, {
 		in:      &ast.Ident{Name: "8ball"},
 		out:     "",
 		isIdent: false,


### PR DESCRIPTION
Currently `IsValidIdent` returns false for the identifier `_1`.
This is not correct: the specification defines as valid identifier
as:

	identifier  = [ "#" | "_#" ] letter { letter | unicode_digit } .

where `letter` includes underscore.

This caused an observed panic in `internal/core/export.(*pivotter)` when it calls
`exporter.ident`.

I was wanting to add the test before introducing the fix, but this isn't
possible with the current `IsValidIdentifer` tests because they check
for consistency between `LabelName` and `IsValidIdentifier` and the
current logic is not consistent for this case.

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: Icb571edbcac97e7f076497d45a03c7b524d92d20
