### PR TITLE
.github: clarify what we mean by "latest release"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ $ cue version
 
 </pre>
 
-### Does this issue reproduce with the latest release?
+### Does this issue reproduce with the latest stable release?
 
 
 


### PR DESCRIPTION
In Go, "latest" tends to mean "latest stable" due to `@latest` being a
valid version suffix when referring to Go modules.

However, in the broader software ecosystem, it's less clear.
For example, "latest" tags in Docker tend to mean any latest version,
which might be stable or not.
Even if a user only considers our releases to be valid versions,
we also do pre-releases like betas.

Clarify what we mean.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I265ad5dac075f4f4dc214fd974ef9a6dcefae7f1
