### PR TITLE
internal/ci: only run release workflow on main repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    if: ${{github.repository == 'cue-lang/cue'}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -42,6 +42,7 @@ release: _base.#bashWorkflow & {
 	}
 	jobs: goreleaser: {
 		"runs-on": _#linuxMachine
+		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
 		steps: [
 			_base.#checkoutCode & {
 				with: "fetch-depth": 0


### PR DESCRIPTION
The only workflow we need to have running on the trybot repo is the
trybot workflow itself. This workflow updates the caches for workflows
in the trybot repo, so that the fake PRs that we create there can use
up-to-date caches when they themselves run the trybot (and other)
workflows.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ibcd72f258911e528dfeb04fced84ca33baef33d5
