### PR TITLE
cue/load: add initial module.cue schema

### DIFF
--- a/cue/load/module.go
+++ b/cue/load/module.go
@@ -1,0 +1,83 @@
+package load
+
+import (
+	_ "embed"
+	"io"
+
+	"path/filepath"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal/core/runtime"
+)
+
+//go:embed moduleschema.cue
+var moduleSchema []byte
+
+type modFile struct {
+	Module string `json:"module"`
+}
+
+// loadModule loads the module file, resolves and downloads module
+// dependencies. It sets c.Module if it's empty or checks it for
+// consistency with the module file otherwise.
+func (c *Config) loadModule() error {
+	// TODO: also make this work if run from outside the module?
+	mod := filepath.Join(c.ModuleRoot, modDir)
+	info, cerr := c.fileSystem.stat(mod)
+	if cerr != nil {
+		return nil
+	}
+	// TODO remove support for legacy non-directory module.cue file
+	// by returning an error if info.IsDir is false.
+	if info.IsDir() {
+		mod = filepath.Join(mod, moduleFile)
+	}
+	f, cerr := c.fileSystem.openFile(mod)
+	if cerr != nil {
+		return nil
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	// TODO: move to full build again
+	file, err := parser.ParseFile("load", data)
+	if err != nil {
+		return errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
+	}
+	// TODO disallow non-data-mode CUE.
+
+	ctx := (*cue.Context)(runtime.New())
+	schemav := ctx.CompileBytes(moduleSchema, cue.Filename("$cueroot/cue/load/moduleschema.cue"))
+	if err := schemav.Validate(); err != nil {
+		return errors.Wrapf(err, token.NoPos, "internal error: invalid CUE module.cue schema")
+	}
+	v := ctx.BuildFile(file)
+	if err := v.Validate(cue.Concrete(true)); err != nil {
+		return errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
+	}
+	v = v.Unify(schemav)
+	if err := v.Validate(); err != nil {
+		return errors.Wrapf(err, token.NoPos, "invalid cue.mod file")
+	}
+	var mf modFile
+	if err := v.Decode(&mf); err != nil {
+		return errors.Wrapf(err, token.NoPos, "internal error: cannot decode into modFile struct (\nfile %q\ncontents %q\nvalue %#v\n)", mod, data, v)
+	}
+	if mf.Module == "" {
+		// Backward compatibility: allow empty module.cue file.
+		// TODO maybe check that the rest of the fields are empty too?
+		return nil
+	}
+	if c.Module != "" && c.Module != mf.Module {
+		return errors.Newf(token.NoPos, "inconsistent modules: got %q, want %q", mf.Module, c.Module)
+	}
+	c.Module = mf.Module
+	c.modFile = &mf
+	return nil
+}

--- a/cue/load/moduleschema.cue
+++ b/cue/load/moduleschema.cue
@@ -1,0 +1,11 @@
+// module indicates the module's import path.
+// For legacy reasons, we allow a missing module
+// directory and an empty module directive.
+module?: #Module | ""
+
+// #Module constraints a module path.
+// TODO encode the module path rules as regexp:
+// WIP: (([\-_~a-zA-Z0-9][.\-_~a-zA-Z0-9]*[\-_~a-zA-Z0-9])|([\-_~a-zA-Z0-9]))(/([\-_~a-zA-Z0-9][.\-_~a-zA-Z0-9]*[\-_~a-zA-Z0-9])|([\-_~a-zA-Z0-9]))*
+#Module:            =~"^[^@]+$"
+
+// TODO add the rest of the module schema definition.


### PR DESCRIPTION
This adds the module.cue file format definition and verifies against it
when loading the configuration. We only add the existing single `module`
field for now.

One awkwardness: by decoding into a Go struct, we lose information about
the position of the resulting errors. I'm not sure if the best solution
to that is to avoid decoding into a struct (with resulting increase in
decoding complexity), or to use some additional mechanism to recover
position information from a path when producing an error. For now,
we just lose the position info.

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I7339b96df9c195eeb02fda5197e790d15a6aad1d
