### PR TITLE
pkg/list: simply template for Ascending

### DIFF
--- a/pkg/list/pkg.go
+++ b/pkg/list/pkg.go
@@ -293,7 +293,7 @@ var pkg = &internal.Package{
 		T:    number | string
 		x:    T
 		y:    T
-		less: true && x < y
+		less: x < y
 	}
 	Descending: {
 		Comparer

--- a/pkg/list/sort.cue
+++ b/pkg/list/sort.cue
@@ -28,11 +28,10 @@ Comparer: {
 //     list.Sort(a, list.Ascending)
 Ascending: {
 	Comparer
-	T: number | string
-	x: T
-	y: T
-	// TODO: the following will be fixed when removing old-school templating.
-	less: true && (x < y)
+	T:    number | string
+	x:    T
+	y:    T
+	less: x < y
 }
 
 // Descending defines a Comparer to sort comparable values in decreasing order.
@@ -44,5 +43,5 @@ Descending: {
 	T:    number | string
 	x:    T
 	y:    T
-	less: (x > y)
+	less: x > y
 }

--- a/pkg/list/testdata/gen.txtar
+++ b/pkg/list/testdata/gen.txtar
@@ -100,7 +100,7 @@ t36: error in call to list.Slice: slice bounds out of range:
     ./in.cue:38:6
 t40: error in call to list.Sort: 2 errors in empty disjunction::
     ./in.cue:46:6
-    list:13:17
+    list:13:9
 t42: invalid list element 0 in argument 0 to call: cannot use value 1 (int) as string:
     ./in.cue:48:6
     ./in.cue:48:24
@@ -110,7 +110,7 @@ t49: error in call to list.Take: negative index:
     ./in.cue:55:6
 t54: error in call to list.Sort: 2 errors in empty disjunction::
     ./in.cue:60:6
-    list:13:17
+    list:13:9
 
 Result:
 t1: 2.5


### PR DESCRIPTION
The parentheses are a holdover of old school CUE which
used <a>: b for pattern constraints, instead of [a]: b.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Ia39110623c779a56e6dce6928c7d816e75f86855
