### PR TITLE
cmd/cue: remove use of stderr directive

### DIFF
--- a/cmd/cue/cmd/testdata/script/export_incomplete.txtar
+++ b/cmd/cue/cmd/testdata/script/export_incomplete.txtar
@@ -1,25 +1,27 @@
+# TODO: line numbers for errors.
+
 #Issue 1153
 #Issue 1152
 
 # Default export mode
 ! exec cue export x.cue
-stderr 'incomplete'
+cmp stderr out/stderr
 
 # JSON
 ! exec cue export --out json x.cue
-stderr 'incomplete'
+cmp stderr out/stderr
 
 # Yaml
 ! exec cue export --out yaml x.cue
-stderr 'incomplete'
+cmp stderr out/stderr
 
 # CUE data
 ! exec cue export --out cue x.cue
-stderr 'incomplete'
+cmp stderr out/stderr
 
 # Concrete
 ! exec cue eval -c x.cue
-stderr 'incomplete'
+cmp stderr out/stderr
 
 # CUE
 exec cue eval --out cue x.cue
@@ -46,3 +48,5 @@ V2: ("x" | "y") | *#SomeBaseType.#AUTO
 }
 V1: "z"
 V2: "x" | "y"
+-- out/stderr --
+V2: incomplete value "x" | "y"


### PR DESCRIPTION
The stderr directive makes it hard to search for error
strings in tests and hides when line numbers are not
properly output.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: I1b560047a819479169c87b433a5b18ef2ee3e75e
