### PR TITLE
internal/updater: add path iterator

### DIFF
--- a/internal/updater/pathiter.go
+++ b/internal/updater/pathiter.go
@@ -1,0 +1,44 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updater
+
+import "cuelang.org/go/cue"
+
+// VisitFunc is called for each path-value pair in a set visit.
+type VisitFunc func(p cue.Path, v cue.Value)
+
+// VisitPaths calls f for every path-value pair in v. Only regular fields
+// are visited.
+func VisitPaths(v cue.Value, f VisitFunc) {
+	var p pathIter
+	p.iter(v, f)
+}
+
+type pathIter struct {
+	path []cue.Selector
+}
+
+func (p *pathIter) iter(v cue.Value, f VisitFunc) {
+	if v.IncompleteKind()&^(cue.StructKind|cue.ListKind) != 0 {
+		f(cue.MakePath(p.path...), v)
+	}
+
+	for i, _ := v.Fields(); i.Next(); {
+		n := len(p.path)
+		p.path = append(p.path, i.Selector())
+		p.iter(i.Value(), f)
+		p.path = p.path[:n]
+	}
+}

--- a/internal/updater/pathiter_test.go
+++ b/internal/updater/pathiter_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updater
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+)
+
+func TestVisitPaths(t *testing.T) {
+	sa := func(a ...string) string { return strings.Join(a, "\n") }
+	testCases := []struct {
+		in  string
+		out string
+	}{{
+		in:  "1",
+		out: sa(": 1"),
+	}, {
+		in:  "a: b: c: 1",
+		out: sa("a.b.c: 1"),
+	}, {
+		in: `a: b: {
+			c: 1,
+			d: "q",
+		}`,
+		out: sa(
+			"a.b.c: 1",
+			`a.b.d: "q"`,
+		),
+	}, {
+		in: `a: b: {
+				4,
+				#c: 1,
+				#d: "q",
+			}
+			a: c: 5`,
+		out: sa(
+			"a.b: 4",
+			"a.c: 5",
+		),
+	}}
+	ctx := cuecontext.New()
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			v := ctx.CompileString(tc.in)
+			a := []string{}
+			VisitPaths(v, func(p cue.Path, v cue.Value) {
+				a = append(a, fmt.Sprintf("%v: %v", p, v))
+			})
+			got := sa(a...)
+			if got != tc.out {
+				t.Errorf("got %v, want %v", got, tc.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add iterator for visiting all path-value pairs in
a cue.Value. This is added as internal as the exact
API is still TBD.

The updater package is intended to be used for
updating the modules.cue file.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: I5a3a9daebd6b3c28585ab0e9abd0356a8a09d4c3
