### PR TITLE
cue/context: support internal interpreters

### DIFF
--- a/cue/cuecontext/cuecontext.go
+++ b/cue/cuecontext/cuecontext.go
@@ -22,10 +22,20 @@ import (
 )
 
 // Option controls a build context.
-type Option interface{ buildOption() }
+type Option func(r *runtime.Runtime)
 
 // New creates a new Context.
 func New(options ...Option) *cue.Context {
 	r := runtime.New()
+	for _, fn := range options {
+		fn(r)
+	}
 	return (*cue.Context)(r)
+}
+
+// Interpreter associates an interpreter for external code with this context.
+func Interpreter(key string, i runtime.Interpreter) Option {
+	return func(r *runtime.Runtime) {
+		r.SetInterpreter(key, i)
+	}
 }

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -51,7 +51,10 @@ type Attr struct {
 	Body   string
 	Kind   AttrKind
 	Fields []KeyValue
-	Err    error
+
+	// TODO: change this and other errors to errors.Error so that
+	// position information can be preserved.
+	Err errors.Error
 }
 
 // NewNonExisting creates a non-existing attribute.

--- a/internal/core/runtime/build.go
+++ b/internal/core/runtime/build.go
@@ -80,6 +80,8 @@ func (x *Runtime) Build(cfg *Config, b *build.Instance) (v *adt.Vertex, errs err
 	v, err = compile.Files(cc, x, b.ID(), b.Files...)
 	errs = errors.Append(errs, err)
 
+	errs = errors.Append(errs, x.injectImplementations(b, v))
+
 	if errs != nil {
 		v = adt.ToVertex(&adt.Bottom{Err: errs})
 		b.Err = errs

--- a/internal/core/runtime/extern.go
+++ b/internal/core/runtime/extern.go
@@ -1,0 +1,297 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/internal"
+	"cuelang.org/go/internal/core/adt"
+	"cuelang.org/go/internal/core/walk"
+)
+
+// SetInterpreter sets the interpreter for extern type key.
+func (r *Runtime) SetInterpreter(key string, i Interpreter) {
+	if r.interpreters == nil {
+		r.interpreters = map[string]Interpreter{}
+	}
+	r.interpreters[key] = i
+}
+
+// Interpreter defines an entrypoint for creating per-package interpreters.
+type Interpreter interface {
+	// Init creates a compiler for built instance b and reports any errors.
+	Init(b *build.Instance) (Compiler, errors.Error)
+}
+
+// A Compiler composes an adt.Builtin for an external function implementation.
+type Compiler interface {
+	// Compile creates a builtin for the given function name and attribute.
+	// funcName is set to "name" value in a if it exists.
+	Compile(funcName string, a *internal.Attr) (*adt.Builtin, errors.Error)
+}
+
+func (r *Runtime) injectImplementations(b *build.Instance, v *adt.Vertex) (errs errors.Error) {
+	if r.interpreters == nil {
+		return nil
+	}
+
+	d := &externDecorator{
+		runtime: r,
+		pkg:     b,
+	}
+
+	for _, f := range b.Files {
+		d.errs = errors.Append(d.errs, d.addFile(f))
+	}
+
+	for _, c := range v.Conjuncts {
+		d.decorateConjunct(c.Elem())
+	}
+
+	return d.errs
+}
+
+// externDecorator locates extern attributes and calls the relevant interpreters
+// to inject builtins.
+//
+// This is a two-pass algorithm: in the first pass, all ast.Files are processed
+// to build an index from *ast.Fields to attributes. In the second phase, the
+// corresponding adt.Fields are located in the ADT and decorated with the
+// builtins.
+type externDecorator struct {
+	runtime *Runtime
+	pkg     *build.Instance
+
+	runtimes   map[string]Compiler
+	fields     map[*ast.Field]fieldInfo
+	fieldStack []*ast.Field
+
+	errs errors.Error
+}
+
+type fieldInfo struct {
+	file     *ast.File
+	extern   string
+	funcName string
+	attrBody string
+	attr     *ast.Attribute
+}
+
+// addFile finds injection points for external implementations of
+// Builtins.
+func (d *externDecorator) addFile(f *ast.File) (errs errors.Error) {
+	var (
+		hasPkg   = false
+		i        = 0
+		kind     string
+		fileAttr *ast.Attribute
+	)
+
+	// Only process files with file-level "@extern(name)" attribute.
+loop:
+	for ; i < len(f.Decls); i++ {
+		switch a := f.Decls[i].(type) {
+		case *ast.Package:
+			hasPkg = true
+			break loop
+
+		case *ast.Attribute:
+			key, body := a.Split()
+			if key != "extern" {
+				continue
+			}
+			fileAttr = a
+
+			attr := internal.ParseAttrBody(a.Pos(), body)
+			if attr.Err != nil {
+				return attr.Err
+			}
+			k, err := attr.String(0)
+			if err != nil {
+				// Unreachable.
+				return errors.Newf(a.Pos(), "%s", err)
+			}
+
+			if k == "" {
+				return errors.Newf(a.Pos(), "interpreter name must be non-empty")
+			}
+
+			if kind != "" {
+				return errors.Newf(a.Pos(),
+					"only one file-level extern attribute allowed per file")
+
+			}
+			kind = k
+
+			if d.runtimes == nil {
+				d.runtimes = map[string]Compiler{}
+				d.fields = map[*ast.Field]fieldInfo{}
+			}
+
+			if d.runtimes[kind] != nil {
+				break
+			}
+
+			x := d.runtime.interpreters[kind]
+			if x == nil {
+				return errors.Newf(a.Pos(), "no interpreter defined for %q", kind)
+			}
+
+			fn, cerr := x.Init(d.pkg)
+			if cerr != nil {
+				return cerr
+			}
+			if fn == nil {
+				return nil
+			}
+			d.runtimes[kind] = fn
+		}
+	}
+
+	switch {
+	case fileAttr != nil && hasPkg:
+		// Success: continue
+
+	case fileAttr == nil && !hasPkg:
+		// Nothing to see here.
+		return nil
+
+	case fileAttr != nil && !hasPkg:
+		return errors.Append(errs, errors.Newf(fileAttr.Pos(),
+			"extern attribute without package clause"))
+
+	case fileAttr == nil && hasPkg:
+		// Check that there are no top-level extern attributes.
+		for i++; i < len(f.Decls); i++ {
+			x, ok := f.Decls[i].(*ast.Attribute)
+			if !ok {
+				continue
+			}
+			if key, _ := x.Split(); key == "extern" {
+				errs = errors.Append(errs, errors.Newf(x.Pos(),
+					"extern attribute must appear before package clause"))
+			}
+		}
+		return errs
+	}
+
+	// Collect all *ast.Fields with extern attributes.
+	// Both of the following forms are allowed:
+	//  	a: _ @extern(...)
+	//      a: { _, @extern(...) }
+	// consistent with attribute implementation recommendations.
+	ast.Walk(&ast.File{Decls: f.Decls[i:]}, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.Field:
+			d.fieldStack = append(d.fieldStack, x)
+
+		case *ast.Attribute:
+			key, body := x.Split()
+			if key != "extern" {
+				break
+			}
+
+			lastField := len(d.fieldStack) - 1
+			if lastField < 0 {
+				errs = errors.Append(errs, errors.Newf(x.Pos(),
+					"extern attribute not associated with field"))
+				return true
+			}
+
+			f := d.fieldStack[lastField]
+
+			if _, ok := d.fields[f]; ok {
+				errs = errors.Append(errs, errors.Newf(x.Pos(),
+					"duplicate extern attributes"))
+				return true
+			}
+
+			name, isIdent, err := ast.LabelName(f.Label)
+			if err != nil || !isIdent {
+				b, _ := format.Node(f.Label)
+				errs = errors.Append(errs, errors.Newf(x.Pos(),
+					"can only define functions for fields with identifier names, found %v", string(b)))
+			}
+
+			d.fields[f] = fieldInfo{
+				extern:   kind,
+				funcName: name,
+				attrBody: body,
+				attr:     x,
+			}
+		}
+
+		return true
+
+	}, func(n ast.Node) {
+		switch n.(type) {
+		case *ast.Field:
+			d.fieldStack = d.fieldStack[:len(d.fieldStack)-1]
+		}
+	})
+
+	return errs
+}
+
+func (d *externDecorator) decorateConjunct(e adt.Elem) {
+	w := walk.Visitor{Before: d.processADTNode}
+	w.Elem(e)
+}
+
+func (d *externDecorator) processADTNode(n adt.Node) bool {
+	f, ok := n.(*adt.Field)
+	if !ok {
+		return true
+	}
+
+	info, ok := d.fields[f.Src]
+	if !ok {
+		return true
+	}
+
+	ic, ok := d.runtimes[info.extern]
+	if !ok {
+		// An error for a missing runtime was already reported earlier,
+		// if applicable.
+		return true
+	}
+
+	attr := internal.ParseAttrBody(info.attr.Pos(), info.attrBody)
+	if attr.Err != nil {
+		d.errs = errors.Append(d.errs, attr.Err)
+		return true
+	}
+	name := info.funcName
+	if str, ok, _ := attr.Lookup(1, "name"); ok {
+		name = str
+	}
+
+	b, err := ic.Compile(name, &attr)
+	if err != nil {
+		d.errs = errors.Append(d.errs, err)
+		return true
+	}
+
+	f.Value = &adt.BinaryExpr{
+		Op: adt.AndOp,
+		X:  f.Value,
+		Y:  b,
+	}
+
+	return true
+}

--- a/internal/core/runtime/extern_test.go
+++ b/internal/core/runtime/extern_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal"
+	"cuelang.org/go/internal/core/adt"
+	"cuelang.org/go/internal/core/runtime"
+	"cuelang.org/go/internal/cuetxtar"
+)
+
+func Test(t *testing.T) {
+	test := cuetxtar.TxTarTest{
+		Root: "testdata/",
+		Name: "extern",
+	}
+
+	test.Run(t, func(t *cuetxtar.Test) {
+		interpreter := &interpreterFake{files: map[string]int{}}
+		ctx := cuecontext.New(cuecontext.Interpreter("test", interpreter))
+
+		b := t.Instance()
+		v := ctx.BuildInstance(b)
+		if err := v.Err(); err != nil {
+			t.WriteErrors(errors.Promote(err, "test"))
+			return
+		}
+
+		fmt.Fprintf(t, "%v\n", v)
+	})
+}
+
+type interpreterFake struct {
+	files map[string]int
+}
+
+func (i *interpreterFake) Init(b *build.Instance) (runtime.Compiler, errors.Error) {
+	switch b.PkgName {
+	case "failinit":
+		return nil, errors.Newf(token.NoPos, "TEST: fail initialization")
+	case "nullinit":
+		return nil, nil
+	}
+	return i, nil
+}
+
+func (i *interpreterFake) Compile(funcName string, a *internal.Attr) (*adt.Builtin, errors.Error) {
+	if ok, _ := a.Flag(1, "fail"); ok {
+		return nil, errors.Newf(token.NoPos, "TEST: fail compilation")
+	}
+
+	str, ok, err := a.Lookup(1, "err")
+	if err != nil {
+		return nil, errors.Promote(err, "test")
+	}
+
+	if ok {
+		return nil, errors.Newf(token.NoPos, "%s", str)
+	}
+
+	if str, err = a.String(0); err != nil {
+		return nil, errors.Promote(err, "test")
+	}
+
+	if _, ok := i.files[str]; !ok {
+		i.files[str] = len(i.files) + 1
+	}
+
+	return &adt.Builtin{
+		Name:   "impl" + funcName + strconv.Itoa(i.files[str]),
+		Params: []adt.Param{{Value: &adt.BasicType{K: adt.IntKind}}},
+		Result: adt.IntKind,
+	}, nil
+}

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -23,6 +23,9 @@ type Runtime struct {
 	index *index
 
 	loaded map[*build.Instance]interface{}
+
+	// interpreters implement extern functionality.
+	interpreters map[string]Interpreter
 }
 
 func (r *Runtime) SetBuildData(b *build.Instance, x interface{}) {

--- a/internal/core/runtime/testdata/_debug.txtar
+++ b/internal/core/runtime/testdata/_debug.txtar
@@ -1,0 +1,13 @@
+// This file is ordered first and is added as a convenience debugging tool.
+// Do not remove.
+-- a_debug.cue --
+@extern("test")
+
+package foo
+
+Foo: _ @extern(file1.xx, abi=c, sig="func(int)int")
+
+-- out/extern --
+{
+	Foo: implFoo1
+}

--- a/internal/core/runtime/testdata/basic.txtar
+++ b/internal/core/runtime/testdata/basic.txtar
@@ -1,0 +1,30 @@
+-- cue.mod/modules.cue --
+-- file1.cue --
+@extern("test")
+
+package foo
+
+
+Foo: _ @extern(file1.xx, abi=c, sig="func(int)int")
+
+Rename: _ @extern(file1.xx, name=Emaner, abi=c, sig="func(int)int")
+
+-- file2.cue --
+@extern("test")
+
+package foo
+
+
+Bar: {
+	@other()
+	@extern(file2.xx, abi=c, sig="func(int)int")
+	_
+}
+
+-- extern/out --
+-- out/extern --
+{
+	Foo:    implFoo1
+	Bar:    implBar2
+	Rename: implEmaner1
+}

--- a/internal/core/runtime/testdata/compile.txtar
+++ b/internal/core/runtime/testdata/compile.txtar
@@ -1,0 +1,11 @@
+-- compile.cue --
+@extern("test")
+
+// Package name fileinit is used as a marker in the test code to fail
+// initialization.
+package ok
+
+
+foo: _ @extern("file.xx", fail)
+-- out/extern --
+TEST: fail compilation

--- a/internal/core/runtime/testdata/errors.txtar
+++ b/internal/core/runtime/testdata/errors.txtar
@@ -1,0 +1,102 @@
+-- cue.mod/modules.cue --
+
+-- invalid_file_attr.cue --
+@extern("test" foo)
+
+package foo
+
+-- invalid_field_attr.cue --
+
+@extern("test")
+
+// Foo
+
+package foo
+
+Fn1: _ @extern("file1.xx" abi sig)
+
+-- empty_extern.cue --
+@extern()
+
+package foo
+
+Fn2: _ @extern("file1.xx" abi sig)
+
+
+-- unknown_interpreter.cue --
+@extern("wazem")
+
+package foo
+
+Fn3: _ @extern("file1.xx" abi sig)
+
+-- double_extern.cue --
+@extern("test")
+@extern("test")
+
+package foo
+
+Fn4: _ @extern("file1.xx")
+
+-- package_attr.cue --
+@extern("test")
+
+package foo
+
+@extern("file1.xx")
+Fn5: _
+
+-- duplicate.cue --
+@extern("test")
+
+package foo
+
+
+Fn6: _ @extern("file1.xx",sig=func(int)int) @extern("file1.xx", sig=func(int)bool)
+
+Fn7: {
+	@extern("file1.xx",sig=func(int)int)
+	_
+} @extern("file1.xx", sig=func(int)bool)
+
+-- non_ident.cue --
+@extern("test")
+
+package foo
+
+
+"a-b": _ @extern("file1.xx",sig=func(int)int)
+
+[string]: _ @extern("file1.xx",sig=func(int)int)
+
+-- late_extern.cue --
+package foo
+
+@extern("test")
+
+
+Foo: _ @extern(file1.xx, abi=c, sig="func(int)int")
+
+-- out/extern --
+only one file-level extern attribute allowed per file:
+    ./double_extern.cue:2:1
+duplicate extern attributes:
+    ./duplicate.cue:6:45
+duplicate extern attributes:
+    ./duplicate.cue:11:3
+interpreter name must be non-empty:
+    ./empty_extern.cue:1:1
+invalid attribute: expected comma:
+    ./invalid_field_attr.cue:8:8
+invalid attribute: expected comma:
+    ./invalid_file_attr.cue:1:1
+extern attribute must appear before package clause:
+    ./late_extern.cue:3:1
+can only define functions for fields with identifier names, found "a-b":
+    ./non_ident.cue:6:10
+can only define functions for fields with identifier names, found [string]:
+    ./non_ident.cue:8:13
+extern attribute not associated with field:
+    ./package_attr.cue:5:1
+no interpreter defined for "wazem":
+    ./unknown_interpreter.cue:1:1

--- a/internal/core/runtime/testdata/failinit.txtar
+++ b/internal/core/runtime/testdata/failinit.txtar
@@ -1,0 +1,12 @@
+-- init.cue --
+@extern("test")
+
+// Package name failinit is used as a marker in the test code to fail
+// initialization.
+package failinit
+
+
+foo: _ @extern("file.xx")
+
+-- out/extern --
+TEST: fail initialization

--- a/internal/core/runtime/testdata/nested.txtar
+++ b/internal/core/runtime/testdata/nested.txtar
@@ -1,0 +1,34 @@
+-- cue.mod/modules.cue --
+-- file1.cue --
+@extern("test")
+
+package foo
+
+
+a: Foo: _ @extern(file1.xx, abi=c, sig="func(int)int")
+
+a: Rename: _ @extern(file1.xx, name=Emaner, abi=c, sig="func(int)int")
+
+-- file2.cue --
+@extern("test")
+
+package foo
+
+
+a: foo: Bar: {
+	@other()
+	@extern(file2.xx, abi=c, sig="func(int)int")
+	_
+}
+
+-- extern/out --
+-- out/extern --
+{
+	a: {
+		Foo:    implFoo1
+		Rename: implEmaner1
+		foo: {
+			Bar: implBar2
+		}
+	}
+}

--- a/internal/core/runtime/testdata/no_top_extern.txtar
+++ b/internal/core/runtime/testdata/no_top_extern.txtar
@@ -1,0 +1,21 @@
+// TODO: We do not generate an error here as it allows files to be processed
+// faster. But maybe it is more user-friendly to report the error.
+-- cue.mod/modules.cue --
+-- in.cue --
+// Missing @extern("test")
+@dummy()
+
+package foo
+
+
+Foo: _ @extern(file.xx, abi=c, sig="func(int)int")
+
+-- extern/out --
+-- out/extern/config --
+{
+	Foo: _
+}
+-- out/extern --
+{
+	Foo: _
+}

--- a/internal/core/runtime/testdata/none.txtar
+++ b/internal/core/runtime/testdata/none.txtar
@@ -1,0 +1,7 @@
+-- cue.mod/modules.cue --
+-- in.cue --
+a: 2
+-- out/extern --
+{
+	a: 2
+}

--- a/internal/core/runtime/testdata/nopkg.txtar
+++ b/internal/core/runtime/testdata/nopkg.txtar
@@ -1,0 +1,10 @@
+-- cue.mod/modules.cue --
+-- no_package.cue --
+@extern("test")
+
+
+Foo: _ @extern(file1.xx, abi=c, sig="func(int)int")
+
+-- out/extern --
+extern attribute without package clause:
+    ./no_package.cue:1:1

--- a/internal/core/runtime/testdata/nullinit.txtar
+++ b/internal/core/runtime/testdata/nullinit.txtar
@@ -1,0 +1,14 @@
+-- init.cue --
+@extern("test")
+
+// Package name failinit is used as a marker in the test code to indicate
+// there is nothing to do.
+package nullinit
+
+
+foo: _ @extern("file.xx")
+
+-- out/extern --
+{
+	foo: _
+}


### PR DESCRIPTION
This introduces the hooks needed for implementing a WASM
interpreter to be used in CUE. This API, for now, only supports
internal types.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Id201419028ca8cbac5883809cdbd53ab7aa440cf
