### PR TITLE
internal/core/adt: sharpen condition for scalar setting

### DIFF
--- a/cue/testdata/eval/insertion.txtar
+++ b/cue/testdata/eval/insertion.txtar
@@ -110,13 +110,13 @@ Disjuncts:    77
   embeddingDirect: (struct){
     t1: (string){
       "s"
-      #a: (string){ string }
+      #a: (string){ "s" }
     }
   }
   embeddingExpr: (struct){
     t1: (string){
       "s"
-      #a: (string){ string }
+      #a: (string){ "s" }
     }
   }
   unifiedDirect: (struct){
@@ -188,9 +188,9 @@ Disjuncts:    77
     "str"
     #fn: (string){
       "str"
-      #in: (string){ string }
+      #in: (string){ "str" }
     }
-    #in: (string){ string }
+    #in: (string){ "str" }
   }
 }
 -- out/compile --

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -1369,7 +1369,8 @@ func (n *nodeContext) getValidators(state VertexStatus) BaseValue {
 func (n *nodeContext) maybeSetCache() {
 	// Set BaseValue to scalar, but only if it was not set before. Most notably,
 	// errors should not be discarded.
-	if n.scalar != nil && isCyclePlaceholder(n.node.BaseValue) {
+	_, isErr := n.node.BaseValue.(*Bottom)
+	if n.scalar != nil && (!isErr || isCyclePlaceholder(n.node.BaseValue)) {
 		n.node.BaseValue = n.scalar
 	}
 	// NOTE: this is now handled by associating the nodeContext


### PR DESCRIPTION
Fixes some issues caused by a regression in v0.5.
It is true that a scalar should not discard an error,
but it may override other values, like basic types
or other values of which a concrete scalar may be
an instance of.

Issue #2244

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: I1351b250683f4f17e78cf5974f9423ee081fe568
