### PR TITLE
internal/core/adt: fix possible infinte loop for API usage

### DIFF
--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -356,7 +356,9 @@ func (c *OpContext) Unify(v *Vertex, state VertexStatus) {
 func (n *nodeContext) insertConjuncts(state VertexStatus) bool {
 	// Exit early if we have a concrete value and only need partial results.
 	if state == Partial {
-		for _, c := range n.conjuncts {
+		for n.evaluatingConjunctsPos < len(n.conjuncts) {
+			c := n.conjuncts[n.evaluatingConjunctsPos]
+			n.evaluatingConjunctsPos++
 			if v, ok := c.Elem().(Value); ok && IsConcrete(v) {
 				n.addValueConjunct(c.Env, v, c.CloseInfo)
 			}
@@ -971,6 +973,8 @@ type nodeContext struct {
 	hasCycle    bool // has conjunct with structural cycle
 	hasNonCycle bool // has conjunct without structural cycle
 	depth       int32
+
+	evaluatingConjunctsPos int
 
 	// Disjunction handling
 	disjunctions []envDisjunct

--- a/internal/core/adt/eval_test.go
+++ b/internal/core/adt/eval_test.go
@@ -155,3 +155,14 @@ func BenchmarkUnifyAPI(b *testing.B) {
 		}
 	}
 }
+
+func TestIssue2293(t *testing.T) {
+	adt.Verbosity = 1
+
+	ctx := cuecontext.New()
+	c := `a: {}, a`
+	v1 := ctx.CompileString(c)
+	v2 := ctx.CompileString(c)
+
+	v1.Unify(v2)
+}


### PR DESCRIPTION
When a Vertex is used as a Conjunct directly and evaluated
as Partial, it was possible that an evaluation loop would
result in an infinite loop.

The solution is to ensure that there is always progress
for a given Vertex and Conjunct, even if there is an
evaluation cycle.

Fixes #2293

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Ic52ccc31989c7305d257125dfd1dd944b37cdf4c
