### PR TITLE
internal/core/adt: export arcType and friends

### DIFF
--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -196,8 +196,8 @@ type Vertex struct {
 	// Used for cycle detection.
 	IsDynamic bool
 
-	// arcType indicates the level of optionality of this arc.
-	arcType arcType
+	// ArcType indicates the level of optionality of this arc.
+	ArcType ArcType
 
 	// cyclicReferences is a linked list of internal references pointing to this
 	// Vertex. This is used to shorten the path of some structural cycles.
@@ -230,7 +230,7 @@ type Vertex struct {
 // isDefined indicates whether this arc is a "value" field, and not a constraint
 // or void arc.
 func (v *Vertex) isDefined() bool {
-	return v.arcType == arcMember
+	return v.ArcType == ArcMember
 }
 
 // IsDefined indicates whether this arc is defined meaning it is not a
@@ -245,22 +245,22 @@ func (v *Vertex) IsDefined(c *OpContext) bool {
 	return v.isDefined()
 }
 
-type arcType uint8
+type ArcType uint8
 
 const (
-	// arcMember means that this arc is a normal non-optional field
+	// ArcMember means that this arc is a normal non-optional field
 	// (including regular, hidden, and definition fields).
-	arcMember arcType = iota
+	ArcMember ArcType = iota
 
 	// TODO: define a type for optional arcs. This will be needed for pulling
 	// in optional fields into the Vertex, which, in turn, is needed for
 	// structure sharing, among other things.
 	// We could also define types for required fields and potentially lets.
 
-	// arcVoid means that an arc does not exist. This happens when an arc
+	// ArcVoid means that an arc does not exist. This happens when an arc
 	// is provisionally added as part of a comprehension, but when this
 	// comprehension has not yet yielded any results.
-	arcVoid
+	ArcVoid
 )
 
 func (v *Vertex) Clone() *Vertex {
@@ -746,7 +746,7 @@ func (v *Vertex) Elems() []*Vertex {
 
 // GetArc returns a Vertex for the outgoing arc with label f. It creates and
 // ads one if it doesn't yet exist.
-func (v *Vertex) GetArc(c *OpContext, f Feature, t arcType) (arc *Vertex, isNew bool) {
+func (v *Vertex) GetArc(c *OpContext, f Feature, t ArcType) (arc *Vertex, isNew bool) {
 	arc = v.Lookup(f)
 	if arc != nil {
 		return arc, false
@@ -762,7 +762,7 @@ func (v *Vertex) GetArc(c *OpContext, f Feature, t arcType) (arc *Vertex, isNew 
 				"field %s not allowed by earlier comprehension or reference cycle", f)
 		}
 	}
-	arc = &Vertex{Parent: v, Label: f, arcType: t}
+	arc = &Vertex{Parent: v, Label: f, ArcType: t}
 	v.Arcs = append(v.Arcs, arc)
 	return arc, true
 }
@@ -795,7 +795,7 @@ func (v *Vertex) hasConjunct(c Conjunct) (added bool) {
 	switch c.x.(type) {
 	case *OptionalField, *BulkOptionalField, *Ellipsis:
 	default:
-		v.arcType = arcMember
+		v.ArcType = ArcMember
 	}
 	for _, x := range v.Conjuncts {
 		// TODO: disregard certain fields from comparison (e.g. Refs)?

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -169,7 +169,7 @@ func (n *nodeContext) insertComprehension(
 			case *Field:
 				numFixed++
 
-				arc, _ := n.node.GetArc(n.ctx, f.Label, arcVoid)
+				arc, _ := n.node.GetArc(n.ctx, f.Label, ArcVoid)
 
 				// Create partial comprehension
 				c := &Comprehension{
@@ -193,7 +193,7 @@ func (n *nodeContext) insertComprehension(
 
 				numFixed++
 
-				arc, _ := n.node.GetArc(n.ctx, f.Label, arcVoid)
+				arc, _ := n.node.GetArc(n.ctx, f.Label, ArcVoid)
 				arc.MultiLet = f.IsMulti
 
 				// Create partial comprehension
@@ -405,7 +405,7 @@ func (n *nodeContext) injectComprehensions(allP *[]envYield, allowCycle bool, st
 
 		v := n.node
 		for c := d.leaf; c.parent != nil; c = c.parent {
-			v.arcType = arcMember
+			v.ArcType = ArcMember
 			v = c.arc
 		}
 

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -486,8 +486,8 @@ func (n *nodeContext) postDisjunct(state VertexStatus) {
 
 	switch err := n.getErr(); {
 	case err != nil:
-		if err.Code < IncompleteError && n.node.arcType == arcVoid {
-			n.node.arcType = arcMember
+		if err.Code < IncompleteError && n.node.ArcType == ArcVoid {
+			n.node.ArcType = ArcMember
 		}
 		n.node.BaseValue = err
 		n.errs = nil
@@ -673,7 +673,7 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 		err = incompleteSentinel
 	}
 	if err.Code < IncompleteError {
-		n.node.arcType = arcMember
+		n.node.ArcType = ArcMember
 	}
 	return err
 }
@@ -735,7 +735,7 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 	if state <= Conjuncts &&
 		// Is allowed to go one step back. See Vertex.UpdateStatus.
 		n.node.status <= state+1 &&
-		n.node.arcType != arcVoid {
+		n.node.ArcType != ArcVoid {
 
 		n.node.UpdateStatus(Conjuncts)
 		return
@@ -1994,7 +1994,7 @@ func (n *nodeContext) addStruct(
 // disjunctions.
 func (n *nodeContext) insertField(f Feature, x Conjunct) *Vertex {
 	ctx := n.ctx
-	arc, isNew := n.node.GetArc(ctx, f, arcMember)
+	arc, isNew := n.node.GetArc(ctx, f, ArcMember)
 	if f.IsLet() && !isNew {
 		arc.MultiLet = true
 		return arc

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1912,7 +1912,7 @@ func (x *ForClause) yield(s *compState) {
 		}
 
 		c.Unify(a, Partial)
-		if a.arcType == arcVoid {
+		if a.ArcType == ArcVoid {
 			continue
 		}
 


### PR DESCRIPTION
Needed for optional field rework.
The ArcType will be used to determine whether
a field is regular, optional, or required.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Iae38d61ea2c97726b3dce5570cfd70cfa24da4a4
