### PR TITLE
cmd/cue: add CUE_DEBUG_PARSER_TRACE environment variable

### DIFF
--- a/cmd/cue/cmd/common.go
+++ b/cmd/cue/cmd/common.go
@@ -53,10 +53,15 @@ var defaultConfig = config{
 					version = -1000 + 100
 				}
 			}
-			return parser.ParseFile(name, src,
+			options := []parser.Option{
 				parser.FromVersion(version),
 				parser.ParseComments,
-			)
+			}
+			// TODO: consolidate all options into a single CUE_DEBUG variable.
+			if os.Getenv("CUE_DEBUG_PARSER_TRACE") != "" {
+				options = append(options, parser.Trace)
+			}
+			return parser.ParseFile(name, src, options...)
 		},
 	},
 }


### PR DESCRIPTION
Setting CUE_DEBUG_PARSER_TRACE to a non-empty value will cause the
parser to print a trace of parsed productions.

Change-Id: Ib5494fb31476a31d265e1e02353504ab71a3b986
Signed-off-by: Aram Hăvărneanu <aram@mgk.ro>
