### PR TITLE
internal/ci/gerrithub: update comment to be clearer

### DIFF
--- a/internal/ci/gerrithub/gerrithub.cue
+++ b/internal/ci/gerrithub/gerrithub.cue
@@ -65,8 +65,9 @@ _#linuxMachine: "ubuntu-20.04"
 			if:        "${{ github.event.client_payload.type == '\(#type)' }}"
 			steps: [
 				#writeNetrcFile,
-				// Hack to get the ref (e.g. refs/changes/38/547738/7) in a format we can use in a
-				// branch name, e.g. _547738_7
+				// Out of the entire ref (e.g. refs/changes/38/547738/7) we only
+				// care about the CL number and patchset, (e.g. 547738/7).
+				// Note that gerrithub_ref is two path elements.
 				json.#step & {
 					id: "gerrithub_ref"
 					run: #"""


### PR DESCRIPTION
The script does not replace slashes with underscores,
which is what the comment seems to suggest is intended.
All the script does is keep the last two path elements.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I2a8a95d54fc9b09711e7f346967fe59e2ac37aca
