### PR TITLE
internal/ci: reset git directory timestamps faster

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Reset git directory modification times
-        run: find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} ';'
+        run: touch -t 202211302355 $(find * -type d)
       - name: Restore git file modification times
         uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Go

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Reset git directory modification times
-        run: find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} ';'
+        run: touch -t 202211302355 $(find * -type d)
       - name: Restore git file modification times
         uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Go

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -74,7 +74,7 @@ import (
 	// TODO(mvdan): May be unnecessary once the Go bug above is fixed.
 	json.#step & {
 		name: "Reset git directory modification times"
-		run:  "find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} ';'"
+		run:  "touch -t 202211302355 $(find * -type d)"
 	},
 	json.#step & {
 		name: "Restore git file modification times"


### PR DESCRIPTION
The two added steps after actions/checkout added recently are fast
enough on GitHub Actions with Linux, to the point where they both clock
in at ~0s, not getting close to even one full second.

However, they appear to clock in at 7-8s and 1-2s respectively on both
Mac and Windows. Presumably, this is because those environments are a
bit slower, and syscalls and I/O are a bit slower as well.

As a baseline, when running on my laptop, git-restore-mtime takes 120ms.
In comparison, our existing command for directories takes about 200ms:

	$ time find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} \;

	real  0m0.205s
	user  0m0.163s
	sys   0m0.039s

This seems to agree with the CI numbers: the first of the two steps is
unnecessarily slow. Instead of running the command `touch` separately
for each file, run it on all the files at once, which saves time:

	$ time touch -t 202211302355 $(find * -type d)

	real  0m0.007s
	user  0m0.001s
	sys   0m0.006s

Also note that we can replace `-not -path '*/.*'` to skip over .git/ by
using `*` as an argument to find, which gives the same result.

After this change, both Mac and Windows reset the timestamps on
directories in under a second, much faster than the previous 7-8s.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: If654ec94dae69d477b291af8daefe6cf2b3cfbc8
