### PR TITLE
trybot/I714c70ca5d7f16d87897fdc5cf330358fc99dded/1370ee770222663dd405b8939857c6d2f91d38d3/551247/1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Reset git directory modification times
-        run: find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} ';'
+        run: touch -t 202211302355 $(find * -type d)
       - name: Restore git file modification times
         uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Go

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Reset git directory modification times
-        run: find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} ';'
+        run: touch -t 202211302355 $(find * -type d)
       - name: Restore git file modification times
         uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Go

--- a/cue/load/import_test.go
+++ b/cue/load/import_test.go
@@ -33,7 +33,11 @@ func testMod(dir string) string {
 }
 
 func getInst(pkg, cwd string) (*build.Instance, error) {
-	c, _ := (&Config{Dir: cwd}).complete()
+	// Set ModuleRoot to cwd as well; otherwise we walk the parent directories
+	// all the way to the root of the git repository, causing Go's test caching
+	// to never kick in, as the .git directory almost always changes.
+	// Moreover, it's extra work that isn't useful to the tests.
+	c, _ := (&Config{ModuleRoot: cwd, Dir: cwd}).complete()
 	l := loader{cfg: c}
 	inst := l.newRelInstance(token.NoPos, pkg, c.Package)
 	p := l.importPkg(token.NoPos, inst)[0]

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -74,7 +74,7 @@ import (
 	// TODO(mvdan): May be unnecessary once the Go bug above is fixed.
 	json.#step & {
 		name: "Reset git directory modification times"
-		run:  "find . -not -path '*/.*' -type d -exec touch -t 202211302355 {} ';'"
+		run:  "touch -t 202211302355 $(find * -type d)"
 	},
 	json.#step & {
 		name: "Restore git file modification times"


### PR DESCRIPTION
- internal/ci: reset git directory timestamps faster
- cue/load: don't read parent directories in tests
