### PR TITLE
internal/ci: use actions/cache/restore for non-protected branch

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -47,7 +47,16 @@ jobs:
       - id: go-cache-dir
         name: Get go build/test cache directory
         run: echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
-      - uses: actions/cache@v3
+      - if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-branch.'))
+        uses: actions/cache@v3
+        with:
+          path: |-
+            ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
+            ${{ steps.go-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+      - if: '! (github.ref == ''refs/heads/master'' || startsWith(github.ref, ''refs/heads/release-branch.''))'
+        uses: actions/cache/restore@v3
         with:
           path: |-
             ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -147,6 +147,21 @@ _#cachePre: [
 	},
 	json.#step & {
 		uses: "actions/cache@v3"
+		if:   _#isProtectedBranch
+		with: {
+			path: strings.Join(_#cacheDirs, "\n")
+
+			// GitHub actions caches are immutable. Therefore, use a key which is
+			// unique, but allow the restore to fallback to the most recent cache.
+			// The result is then saved under the new key which will benefit the
+			// next build
+			key:            "${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}"
+			"restore-keys": "${{ runner.os }}-${{ matrix.go-version }}"
+		}
+	},
+	json.#step & {
+		uses: "actions/cache/restore@v3"
+		if:   "! \(_#isProtectedBranch)"
 		with: {
 			path: strings.Join(_#cacheDirs, "\n")
 


### PR DESCRIPTION
CLs are tested by creating PRs in the cue-trybot repo. These PRs are
created against branches that are pushed to the trybot repo.

Such a PR trybot run will have a cache "miss" because the
associated branch will never be known to the cue-trybot
actions cache: each branch is unique to each CL+patchset.

This is as expected.

When such a PR fires the actions workflows, the use of actions/cache
results in a cache miss for the branch associated with the PR, falling
back to the target branch of the PR, per the GitHub docs:

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key

This is also as expected.

However, the use of actions/cache for PRs (that are the result of CL
runtrybot calls) also ends up writing the resulting cache back to a
cache key associated with the branch of the PR. This is entirely
wasteful, because that cache will never be used again (see previous
point about branch being unique to CL+patchset).

Writing back this cache is a waste of time and space.

actions/cache/restore, as its name suggests, only restores from a cache
and does not write back.

This changes makes trybot runs that are not against a protected branch
use actions/cache/restore, leaving the existing behaviour for the
procted branches which is what we want.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Iea6f37612ffd226db60b9e1a16b65503daebdaf2
