### PR TITLE
internal/ci: do not evict caches on push to ci/test

### DIFF
--- a/.github/workflows/evict_caches.yml
+++ b/.github/workflows/evict_caches.yml
@@ -2,9 +2,6 @@
 
 name: Evict caches
 "on":
-  push:
-    branches:
-      - ci/test
   schedule:
     - cron: 0 2 * * *
 jobs:

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -44,9 +44,6 @@ evict_caches: _base.#bashWorkflow & {
 	name: "Evict caches"
 
 	on: {
-		push: {
-			branches: [_base.#testDefaultBranch]
-		}
 		schedule: [
 			// We will run a schedule trybot build 15 minutes later to repopulate the caches
 			{cron: "0 2 * * *"},


### PR DESCRIPTION
Pushing to ci/test is a useful thing for trying out changes to various
workflows. But the evict caches workflow is quite destructive. An
innocuous push to ci/test to try out a change in, say, the trybot
workflow would blast the actions caches in the main CUE repo and the
trybot repo.

Hence, do not run evict_caches on a push to ci/test.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Iee9727697975c6a8d9d610de7d5ee2b5cf76afd8
