### PR TITLE
internal/ci: rerun trybot workflows post eviction

### DIFF
--- a/.github/workflows/evict_caches.yml
+++ b/.github/workflows/evict_caches.yml
@@ -28,3 +28,19 @@ jobs:
           		gh actions-cache delete --confirm $j
           	done
           done
+
+          # Now trigger the most recent workflow run on each of the default branches
+          for j in $(curl -s -L   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}"  -H "X-GitHub-Api-Version: 2022-11-28"   https://api.github.com/repos/cue-lang/cue/branches | jq -r '.[] | .name')
+          do
+          	for i in master release-branch.*
+          	do
+          		if [[ "$j" = $i ]]
+          		then
+          			echo "$j is a match with $i"
+          			id=$(curl -s -L   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}"  -H "X-GitHub-Api-Version: 2022-11-28"   "https://api.github.com/repos/cue-lang/cue/actions/workflows/trybot.yml/runs?branch=$j&event=push&per_page=1" | jq '.workflow_runs[] | .id')
+          			curl -s -L   -X POST   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}"  -H "X-GitHub-Api-Version: 2022-11-28"   https://api.github.com/repos/cue-lang/cue/actions/runs/$id/rerun
+          			id=$(curl -s -L   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}"  -H "X-GitHub-Api-Version: 2022-11-28"   "https://api.github.com/repos/cue-lang/cue-trybot/actions/workflows/trybot.yml/runs?branch=$j&event=push&per_page=1" | jq '.workflow_runs[] | .id')
+          			curl -s -L   -X POST   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}"  -H "X-GitHub-Api-Version: 2022-11-28"   https://api.github.com/repos/cue-lang/cue-trybot/actions/runs/$id/rerun
+          		fi
+          	done
+          done

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -11,8 +11,6 @@ name: TryBot
     tags-ignore:
       - v*
   pull_request: {}
-  schedule:
-    - cron: 15 2 * * *
 jobs:
   test:
     strategy:

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -39,10 +39,6 @@ trybot: _base.#bashWorkflow & {
 			"tags-ignore": [core.#releaseTagPattern]
 		}
 		pull_request: {}
-		schedule: [
-			// Run at 0215 each day, 15 mins after the cache eviction
-			{cron: "15 2 * * *"},
-		]
 	}
 
 	jobs: {

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -34,6 +34,8 @@ workflows: [
 		// gerritstatusupdater is running for this repository.
 		//
 		// This name is also used by the CI badge in the top-level README.
+		//
+		// This name is also used in the evict_caches lookups.
 		file:   "trybot.yml"
 		schema: trybot
 	},


### PR DESCRIPTION
We currently rely on a scheduled run of the trybot workflow to
repopulate the actions caches post eviction. This works for the default
branch, against which the scheduled trybot run will happen. However it
does not work for other procted branches, e.g. those branches that match
release-branch.*

Therefore, write a bit of shell that reruns the latest push to $branch
trybot workflow for each branch that matches the protected branch
patterns.

Tested by pushing manually to ci/test prior to this CL.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I2e38b5665d0a41be9876f71511af2f9b588ed696
