### PR TITLE
internal/ci: use a group of cue commands for go:generate

### DIFF
--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -33,13 +33,12 @@ import (
 
 _goos: string @tag(os,var=os)
 
-// genworkflows regenerates the GitHub workflow Yaml definitions.
+// gen.workflows regenerates the GitHub workflow Yaml definitions.
 //
 // See internal/ci/gen.go for details on how this step fits into the sequence
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
-command: genworkflows: {
-
+command: gen: workflows: {
 	for w in github.workflows {
 		"\(w.file)": file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
@@ -50,7 +49,7 @@ command: genworkflows: {
 	}
 }
 
-command: gencodereviewcfg: file.Create & {
+command: gen: codereviewcfg: file.Create & {
 	_dir:     path.FromSlash("../../", path.Unix)
 	filename: path.Join([_dir, "codereview.cfg"], _goos)
 	let res = core.#toCodeReviewCfg & {#input: core.codeReview, _}

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -15,5 +15,4 @@
 package ci
 
 //go:generate go run cuelang.org/go/cmd/cue cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue cmd gen


### PR DESCRIPTION
The ci package currently runs three commands via `go:generate`:

	go run cuelang.org/go/cmd/cue cmd importjsonschema ./vendor
	go run cuelang.org/go/cmd/cue cmd genworkflows
	go run cuelang.org/go/cmd/cue cmd gencodereviewcfg

The second and third are extremely similar.
They both implicitly load and evaluate the current CUE package,
which is surprisingly expensive at about three seconds.
Moreover, they both need to re-link the cmd/cue binary,
since `go run` does not do that for us.

This results in a pretty slow generation step:

	$ time go generate
	real  0m9.721s
	user  0m16.918s
	sys   0m1.048s

If we group both commands under a `gen` command,
then we can simply use `cue cmd gen`,
which helps avoid the cost of both of those factors:

	$ time go generate

	real  0m5.239s
	user  0m8.709s
	sys   0m0.784s

This should especially help CI, where `go generate ./...` takes 30s.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: Ic6200154479621b96125929b8d0395be297e009e
