### PR TITLE
internal/ci: bump pinned version of Go for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.19.7
       - name: Setup qemu
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -26,7 +26,7 @@ _#URLPath: {
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#pinnedReleaseGo: "1.19.3"
+#pinnedReleaseGo: "1.19.7"
 
 #goreleaserVersion: "v1.13.1"
 


### PR DESCRIPTION
For cherry-picking into v0.5.
It's very late in the release cycle to bump to Go 1.20,
but at least we should bump the bugfix version.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I235db8295f0abbaccd1baee4dcb733e85458bd28
