### PR TITLE
internal/ci: bump pinned version of Go for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.19.7
       - name: Setup qemu
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -26,7 +26,7 @@ _#URLPath: {
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#pinnedReleaseGo: "1.19.3"
+#pinnedReleaseGo: "1.19.7"
 
 #goreleaserVersion: "v1.13.1"
 


### PR DESCRIPTION
For cherry-picking into v0.5.
It's very late in the release cycle to bump to Go 1.20,
but at least we should bump the bugfix version.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I235db8295f0abbaccd1baee4dcb733e85458bd28
Reviewed-on: https://review.gerrithub.io/c/cue-lang/cue/+/551308
Reviewed-by: Paul Jolly <paul@myitcv.io>
Unity-Result: CUEcueckoo <cueckoo@cuelang.org>
TryBot-Result: CUEcueckoo <cueckoo@cuelang.org>
(cherry picked from commit 30b9e82232b7edeb5c3d8eb418277ed253f0ee6e)
