### PR TITLE
internal/ci: skip test cache on procted branches

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -63,6 +63,8 @@ jobs:
             ${{ steps.go-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+      - if: github.repository == 'cue-lang/cue' && ((github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-branch.')) || github.ref == 'refs/heads/ci/test')
+        run: go clean -testcache
       - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-22.04')
         name: Early git and code sanity checks
         run: |-

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -53,6 +53,16 @@ trybot: _base.#bashWorkflow & {
 				// are established by running each tool.
 				for v in _#cachePre {v},
 
+				// All tests on protected branches should skip the test cache.
+				// The canonical way to do this is with -count=1. However, we
+				// want the resulting test cache to be valid and current so that
+				// subsequent CLs in the trybot repo can leverage the updated
+				// cache. Therefore, we instead perform a clean of the testcache.
+				json.#step & {
+					if:  "github.repository == '\(core.#githubRepositoryPath)' && (\(_#isProtectedBranch) || github.ref == 'refs/heads/\(_base.#testDefaultBranch)')"
+					run: "go clean -testcache"
+				},
+
 				_base.#earlyChecks & {
 					// These checks don't vary based on the Go version or OS,
 					// so we only need to run them on one of the matrix jobs.


### PR DESCRIPTION
This will help us catch test flakes earlier.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ib7bb727cdedda27b702be8b3fb40e2f797ee4dcc
