### PR TITLE
trybot/Id2fd735bab0ce549861bdd35057743d3bf6a74e3/8169deb608ddf5d9766f09720d28f9134b0226ec/551377/4

### DIFF
--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -12,8 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package core is a collection of features that are common to CUE projects and
-// the workflows they specify.
+// package base is a collection of workflows, jobs, stes etc that are common to
+// CUE projects and the workflows they specify. The package itself needs to be
+// instantiated to parameterise many of the exported definitions.
+//
+// For example a package using base would do something like this:
+//
+//     package workflows
+//
+//     import "cuelang.org/go/internal/ci/base"
+//
+//     // Create an instance of base
+//     _base: base & {
+//         #repositoryURL:                core.#githubRepositoryURL
+//         #defaultBranch:                core.#defaultBranch
+//         #botGitHubUser:                "cueckoo"
+//         #botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"
+//     }
+//
 package base
 
 import (
@@ -26,6 +42,7 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
+// Package parameters
 #repositoryURL:                string
 #defaultBranch:                string
 #testDefaultBranch:            "ci/test"

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -48,6 +48,8 @@ import (
 #testDefaultBranch:            "ci/test"
 #botGitHubUser:                string
 #botGitHubUserTokenSecretsKey: string
+#protectedBranchPatterns: [...string]
+#releaseTagPattern: string
 
 #doNotEditMessage: {
 	#generatedBy: string
@@ -237,4 +239,59 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 			run: "find \(strings.Join(qCacheDirs, " ")) -type f -amin +7200 -delete -print"
 		},
 	]
+}
+
+// #codeReview defines the schema of a codereview.cfg file that
+// sits at the root of a repository. codereview.cfg is the configuration
+// file that drives golang.org/x/review/git-codereview. This config
+// file is also used by github.com/cue-sh/tools/cmd/cueckoo.
+#codeReview: {
+	gerrit?:      string
+	github?:      string
+	"cue-unity"?: string
+}
+
+// #toCodeReviewCfg converts a #codeReview instance to
+// the key: value
+#toCodeReviewCfg: {
+	#input: #codeReview
+	let parts = [ for k, v in #input {k + ": " + v}]
+
+	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
+	strings.Join(parts, "\n")
+}
+
+// _#matchPattern returns a GitHub Actions expression which evaluates whether a
+// variable matches a globbing pattern. For literal patterns it uses "==",
+// and for suffix patterns it uses "startsWith".
+// See https://docs.github.com/en/actions/learn-github-actions/expressions.
+_#matchPattern: {
+	variable: string
+	pattern:  string
+	expr:     [
+			if strings.HasSuffix(pattern, "*") {
+			let prefix = strings.TrimSuffix(pattern, "*")
+			"startsWith(\(variable), '\(prefix)')"
+		},
+		{
+			"\(variable) == '\(pattern)'"
+		},
+	][0]
+}
+
+// #isProtectedBranch is an expression that evaluates to true if the
+// job is running as a result of pushing to one of _#protectedBranchPatterns.
+// It would be nice to use the "contains" builtin for simplicity,
+// but array literals are not yet supported in expressions.
+#isProtectedBranch: {
+	"(" + strings.Join([ for branch in #protectedBranchPatterns {
+		(_#matchPattern & {variable: "github.ref", pattern: "refs/heads/\(branch)"}).expr
+	}], " || ") + ")"
+}
+
+// #isReleaseTag creates a GitHub expression, based on the given release tag
+// pattern, that evaluates to true if called in the context of a workflow that
+// is part of a release.
+#isReleaseTag: {
+	(_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(#releaseTagPattern)"}).expr
 }

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -175,3 +175,66 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 	let parts = strings.Split(#url, "/")
 	strings.Join(list.Slice(parts, 3, len(parts)), "/")
 }
+
+#setupGoActionsCaches: {
+	// #protectedBranchExpr is a GitHub expression
+	// (https://docs.github.com/en/actions/learn-github-actions/expressions)
+	// that evaluates to true if the workflow is running for a commit against a
+	// protected branch.
+	#protectedBranchExpr: string
+
+	let goModCacheDirID = "go-mod-cache-dir"
+	let goCacheDirID = "go-cache-dir"
+
+	// cacheDirs is a convenience variable that includes
+	// GitHub expressions that represent the directories
+	// that participate in Go caching.
+	let cacheDirs = [ "${{ steps.\(goModCacheDirID).outputs.dir }}/cache/download", "${{ steps.\(goCacheDirID).outputs.dir }}"]
+
+	// pre is the list of steps required to establish and initialise the correct
+	// caches for Go-based workflows.
+	pre: [
+		json.#step & {
+			name: "Get go mod cache directory"
+			id:   goModCacheDirID
+			run:  #"echo "dir=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}"#
+		},
+		json.#step & {
+			name: "Get go build/test cache directory"
+			id:   goCacheDirID
+			run:  #"echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}"#
+		},
+		for _, v in [
+			{
+				if:   #protectedBranchExpr
+				uses: "actions/cache@v3"
+			},
+			{
+				if:   "! \(#protectedBranchExpr)"
+				uses: "actions/cache/restore@v3"
+			},
+		] {
+			v & json.#step & {
+				with: {
+					path: strings.Join(cacheDirs, "\n")
+
+					// GitHub actions caches are immutable. Therefore, use a key which is
+					// unique, but allow the restore to fallback to the most recent cache.
+					// The result is then saved under the new key which will benefit the
+					// next build
+					key:            "${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}"
+					"restore-keys": "${{ runner.os }}-${{ matrix.go-version }}"
+				}
+			}
+		},
+	]
+
+	// post is the list of steps that need to be run at the end of
+	// a workflow to "tidy up" following the earlier pre
+	post: [
+		json.#step & {
+			let qCacheDirs = [ for v in cacheDirs {"'\(v)'"}]
+			run: "find \(strings.Join(qCacheDirs, " ")) -type f -amin +7200 -delete -print"
+		},
+	]
+}

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -128,3 +128,23 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 #curlGitHubAPI: #"""
 	curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.\#(#botGitHubUserTokenSecretsKey) }}" -H "X-GitHub-Api-Version: 2022-11-28"
 	"""#
+
+// #codeReview defines the schema of a codereview.cfg file that
+// sits at the root of a repository. codereview.cfg is the configuration
+// file that drives golang.org/x/review/git-codereview. This config
+// file is also used by github.com/cue-sh/tools/cmd/cueckoo.
+#codeReview: {
+	gerrit?:      string
+	github?:      string
+	"cue-unity"?: string
+}
+
+// #toCodeReviewCfg converts a #codeReview instance to
+// the key: value
+#toCodeReviewCfg: {
+	#input: #codeReview
+	let parts = [ for k, v in #input {k + ": " + v}]
+
+	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
+	strings.Join(parts, "\n")
+}

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -295,3 +295,26 @@ _#matchPattern: {
 #isReleaseTag: {
 	(_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(#releaseTagPattern)"}).expr
 }
+
+// Define some shared keys and human-readable names.
+//
+// #trybot.key and #unity.key are shared with
+// github.com/cue-sh/tools/cmd/cueckoo.  The keys are used across various CUE
+// workflows and their consistency in those various locations is therefore
+// crucial. As such, we assert specific values for the keys here rather than
+// just deriving values from the human-readable names.
+//
+// #trybot.name is by the trybot GitHub workflow and by gerritstatusupdater as
+// an identifier in the status updates that are posted as reviews for this
+// workflows, but also as the result label key, e.g.  "TryBot-Result" would be
+// the result label key for the "TryBot" workflow. This name also shows up in
+// the CI badge in the top-level README.
+#trybot: {
+	key:  "trybot" & strings.ToLower(name)
+	name: "TryBot"
+}
+
+#unity: {
+	key:  "unity" & strings.ToLower(name)
+	name: "Unity"
+}

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -17,6 +17,7 @@
 package base
 
 import (
+	"list"
 	"strings"
 	"path"
 	"strconv"
@@ -147,4 +148,13 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 
 	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
 	strings.Join(parts, "\n")
+}
+
+// #URLPath is a temporary measure to derive the path part of a URL.
+//
+// TODO: remove when cuelang.org/issue/1433 lands.
+#URLPath: {
+	#url: string
+	let parts = strings.Split(#url, "/")
+	strings.Join(list.Slice(parts, 3, len(parts)), "/")
 }

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -39,12 +39,13 @@ _goos: string @tag(os,var=os)
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
 command: gen: workflows: {
-	for w in github.workflows {
-		"\(w.file)": file.Create & {
+	for _workflowName, _workflow in github.workflows {
+		let _filename = _workflowName + ".yml"
+		(_filename): file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
-			filename: path.Join([_dir, w.file], _goos)
+			filename: path.Join([_dir, _filename], _goos)
 			let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
-			contents: "# \(donotedit)\n\n\(yaml.Marshal(w.schema))"
+			contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
 		}
 	}
 }

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -53,7 +53,7 @@ command: gen: workflows: {
 command: gen: codereviewcfg: file.Create & {
 	_dir:     path.FromSlash("../../", path.Unix)
 	filename: path.Join([_dir, "codereview.cfg"], _goos)
-	let res = core.#toCodeReviewCfg & {#input: core.codeReview, _}
+	let res = base.#toCodeReviewCfg & {#input: core.codeReview, _}
 	let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
 	contents: "# \(donotedit)\n\n\(res)\n"
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -9,10 +9,10 @@ import (
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
-#githubRepositoryURL:  "https://github.com/cue-lang/cue"
-#gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
-#githubRepositoryPath: _#URLPath & {#url: #githubRepositoryURL, _}
-#unityRepositoryURL:   "https://github.com/cue-unity/unity"
+githubRepositoryURL:  "https://github.com/cue-lang/cue"
+gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
+githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
+unityRepositoryURL:   "https://github.com/cue-unity/unity"
 
 // Not ideal, but hack together something that gives us the path
 // of a URL. In lieu of cuelang.org/issue/1433
@@ -24,34 +24,34 @@ _#URLPath: {
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.
-#latestStableGo: "1.19.x"
+latestStableGo: "1.19.x"
 
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#pinnedReleaseGo: "1.19.7"
+pinnedReleaseGo: "1.19.7"
 
-#goreleaserVersion: "v1.13.1"
+goreleaserVersion: "v1.13.1"
 
-#defaultBranch: "master"
+defaultBranch: "master"
 
-// #releaseBranchPrefix is the git branch name prefix used to identify
+// releaseBranchPrefix is the git branch name prefix used to identify
 // release branches.
-#releaseBranchPrefix: "release-branch."
+releaseBranchPrefix: "release-branch."
 
-// #releaseBranchPattern is the GitHub pattern that corresponds to
-// #releaseBranchPrefix.
-#releaseBranchPattern: #releaseBranchPrefix + "*"
+// releaseBranchPattern is the GitHub pattern that corresponds to
+// releaseBranchPrefix.
+releaseBranchPattern: releaseBranchPrefix + "*"
 
-// #releaseTagPrefix is the prefix used to identify all git tag that correspond
+// releaseTagPrefix is the prefix used to identify all git tag that correspond
 // to semver releases
-#releaseTagPrefix: "v"
+releaseTagPrefix: "v"
 
-// #releaseTagPattern is the GitHub glob pattern that corresponds to
-// #releaseTagPrefix.
-#releaseTagPattern: #releaseTagPrefix + "*"
+// releaseTagPattern is the GitHub glob pattern that corresponds to
+// releaseTagPrefix.
+releaseTagPattern: releaseTagPrefix + "*"
 
-// #zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
+// zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
 // When we create a release branch for v0.$X.0, it's likely that commits on the
 // default branch will from that point onwards be intended for the $X+1
 // version. However, unless we tag the next commit after the release branch, it
@@ -61,11 +61,11 @@ _#URLPath: {
 // A "zero" tag fixes this when applied to the first commit after a release
 // branch. Critically, the -0.dev pre-release suffix is ordered before -alpha.
 // tags.
-#zeroReleaseTagSuffix: "-0.dev"
+zeroReleaseTagSuffix: "-0.dev"
 
-// #zeroReleaseTagPattern is the GitHub glob pattern that corresponds
-// #zeroReleaseTagSuffix.
-#zeroReleaseTagPattern: "*" + #zeroReleaseTagSuffix
+// zeroReleaseTagPattern is the GitHub glob pattern that corresponds
+// zeroReleaseTagSuffix.
+zeroReleaseTagPattern: "*" + zeroReleaseTagSuffix
 
 #codeReview: {
 	gerrit?:      string
@@ -74,9 +74,9 @@ _#URLPath: {
 }
 
 codeReview: #codeReview & {
-	github:      #githubRepositoryURL
-	gerrit:      #gerritRepositoryURL
-	"cue-unity": #unityRepositoryURL
+	github:      githubRepositoryURL
+	gerrit:      gerritRepositoryURL
+	"cue-unity": unityRepositoryURL
 }
 
 // #toCodeReviewCfg converts a #codeReview instance to

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -1,3 +1,6 @@
+// package core contains data values that are commont to all CUE
+// configurations.  This not only includes GitHub workflows, but also things
+// like gerrit configuration etc.
 package core
 
 import (

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -6,6 +6,8 @@ package core
 import (
 	"list"
 	"strings"
+
+	"cuelang.org/go/internal/ci/base"
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
@@ -67,24 +69,8 @@ zeroReleaseTagSuffix: "-0.dev"
 // zeroReleaseTagSuffix.
 zeroReleaseTagPattern: "*" + zeroReleaseTagSuffix
 
-#codeReview: {
-	gerrit?:      string
-	github?:      string
-	"cue-unity"?: string
-}
-
-codeReview: #codeReview & {
+codeReview: base.#codeReview & {
 	github:      githubRepositoryURL
 	gerrit:      gerritRepositoryURL
 	"cue-unity": unityRepositoryURL
-}
-
-// #toCodeReviewCfg converts a #codeReview instance to
-// the key: value
-#toCodeReviewCfg: {
-	#input: #codeReview
-	let parts = [ for k, v in #input {k + ": " + v}]
-
-	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
-	strings.Join(parts, "\n")
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -7,6 +7,11 @@ import (
 	"cuelang.org/go/internal/ci/base"
 )
 
+// The machines that we use
+linuxMachine:   "ubuntu-22.04"
+macosMachine:   "macos-11"
+windowsMachine: "windows-2022"
+
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
 githubRepositoryURL:  "https://github.com/cue-lang/cue"
 gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
@@ -63,3 +68,16 @@ codeReview: base.#codeReview & {
 	gerrit:      gerritRepositoryURL
 	"cue-unity": unityRepositoryURL
 }
+
+// protectedBranchPatterns is a list of glob patterns to match the protected
+// git branches which are continuously used during development on Gerrit.
+// This includes the default branch and release branches,
+// but excludes any others like feature branches or short-lived branches.
+// Note that ci/test is excluded as it is GitHub-only.
+protectedBranchPatterns: [defaultBranch, releaseBranchPattern]
+
+// isLatestLinux returns a GitHub expression that evaluates to true if the job
+// is running on Linux with the latest version of Go. This expression is often
+// used to run certain steps just once per CI workflow, to avoid duplicated
+// work.
+isLatestLinux: "(matrix.go-version == '\(latestStableGo)' && matrix.os == '\(linuxMachine)')"

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -4,25 +4,14 @@
 package core
 
 import (
-	"list"
-	"strings"
-
 	"cuelang.org/go/internal/ci/base"
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
 githubRepositoryURL:  "https://github.com/cue-lang/cue"
 gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
-githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
+githubRepositoryPath: base.#URLPath & {#url: githubRepositoryURL, _}
 unityRepositoryURL:   "https://github.com/cue-unity/unity"
-
-// Not ideal, but hack together something that gives us the path
-// of a URL. In lieu of cuelang.org/issue/1433
-_#URLPath: {
-	#url: string
-	let parts = strings.Split(#url, "/")
-	strings.Join(list.Slice(parts, 3, len(parts)), "/")
-}
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.

--- a/internal/ci/gerrithub/gerrithub.cue
+++ b/internal/ci/gerrithub/gerrithub.cue
@@ -31,7 +31,8 @@ import (
 
 #repositoryURL:                      string
 #gerritHubRepositoryURL:             string
-#trybotRepositoryURL:                *(#repositoryURL + "-" + #dispatchTrybot) | string
+#trybotKey:                          string
+#trybotRepositoryURL:                *(#repositoryURL + "-" + #trybotKey) | string
 #botGitHubUser:                      string
 #botGitHubUserTokenSecretsKey:       string
 #botGitHubUserEmail:                 string
@@ -48,19 +49,14 @@ _#gerritHubHostname: "review.gerrithub.io"
 
 _#linuxMachine: "ubuntu-20.04"
 
-// These constants are defined by github.com/cue-sh/tools/cmd/cueckoo
-// TODO: they probably belong elsewhere
-#dispatchTrybot: "trybot"
-#dispatchUnity:  "unity"
-
 #dispatchWorkflow: json.#Workflow & {
-	#type:                  #dispatchTrybot | #dispatchUnity
+	#type:                  string
 	_#branchNameExpression: "\(#type)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
 	name:                   "Dispatch \(#type)"
 	on: ["repository_dispatch"]
 	jobs: [string]: defaults: run: shell: "bash"
 	jobs: {
-		"\(#type)": {
+		(#type): {
 			"runs-on": _#linuxMachine
 			if:        "${{ github.event.client_payload.type == '\(#type)' }}"
 			steps: [

--- a/internal/ci/gerrithub/gerrithub.cue
+++ b/internal/ci/gerrithub/gerrithub.cue
@@ -49,16 +49,15 @@ _#gerritHubHostname: "review.gerrithub.io"
 
 _#linuxMachine: "ubuntu-20.04"
 
-#dispatchWorkflow: json.#Workflow & {
-	#type:                  string
-	_#branchNameExpression: "\(#type)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
-	name:                   "Dispatch \(#type)"
+#trybotWorkflow: json.#Workflow & {
+	_#branchNameExpression: "\(#trybotKey)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
+	name:                   "Dispatch \(#trybotKey)"
 	on: ["repository_dispatch"]
 	jobs: [string]: defaults: run: shell: "bash"
 	jobs: {
-		(#type): {
+		(#trybotKey): {
 			"runs-on": _#linuxMachine
-			if:        "${{ github.event.client_payload.type == '\(#type)' }}"
+			if:        "${{ github.event.client_payload.type == '\(#trybotKey)' }}"
 			steps: [
 				#writeNetrcFile,
 				// Out of the entire ref (e.g. refs/changes/38/547738/7) we only
@@ -72,7 +71,7 @@ _#linuxMachine: "ubuntu-20.04"
 						"""#
 				},
 				json.#step & {
-					name: "Trigger \(#type)"
+					name: "Trigger \(#trybotKey)"
 					run:  """
 						mkdir tmpgit
 						cd tmpgit

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -54,7 +54,7 @@ workflows: evict_caches: _base.#bashWorkflow & {
 	jobs: {
 		test: {
 			// We only want to run this in the main repo
-			if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+			if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 			"runs-on": _#linuxMachine
 			steps: [
 				json.#step & {
@@ -77,7 +77,7 @@ workflows: evict_caches: _base.#bashWorkflow & {
 
 						echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
 						gh extension install actions/gh-actions-cache
-						for i in \(core.#githubRepositoryURL) \(core.#githubRepositoryURL)-trybot
+						for i in \(core.githubRepositoryURL) \(core.githubRepositoryURL)-trybot
 						do
 							echo "Evicting caches for $i"
 							cd $(mktemp -d)
@@ -92,7 +92,7 @@ workflows: evict_caches: _base.#bashWorkflow & {
 						# Now trigger the most recent workflow run on each of the default branches.
 						# We do this by listing all the branches on the main repo and finding those
 						# which match the protected branch patterns (globs).
-						for j in $(\(_base.#curlGitHubAPI) -f https://api.github.com/repos/\(core.#githubRepositoryPath)/branches | jq -r '.[] | .name')
+						for j in $(\(_base.#curlGitHubAPI) -f https://api.github.com/repos/\(core.githubRepositoryPath)/branches | jq -r '.[] | .name')
 						do
 							for i in \(branchPatterns)
 							do
@@ -101,8 +101,8 @@ workflows: evict_caches: _base.#bashWorkflow & {
 								fi
 
 								echo "$j is a match with $i"
-								\(rerunLatestWorkflow & {#repo: core.#githubRepositoryPath, #branch: "$j", _})
-								\(rerunLatestWorkflow & {#repo: core.#githubRepositoryPath + "-trybot", #branch: "$j", _})
+								\(rerunLatestWorkflow & {#repo: core.githubRepositoryPath, #branch: "$j", _})
+								\(rerunLatestWorkflow & {#repo: core.githubRepositoryPath + "-trybot", #branch: "$j", _})
 							done
 						done
 						"""

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -55,10 +55,10 @@ workflows: evict_caches: _base.#bashWorkflow & {
 		test: {
 			// We only want to run this in the main repo
 			if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
-			"runs-on": _#linuxMachine
+			"runs-on": core.linuxMachine
 			steps: [
 				json.#step & {
-					let branchPatterns = strings.Join(_#protectedBranchPatterns, " ")
+					let branchPatterns = strings.Join(core.protectedBranchPatterns, " ")
 
 					// rerunLatestWorkflow runs the latest trybot workflow in the
 					// specified repo for branches that match the specified branch.

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -42,7 +42,7 @@ import (
 //
 // In testing with @mvdan, this resulted in cache sizes for Linux dropping from
 // ~1GB to ~125MB. This is a considerable saving.
-evict_caches: _base.#bashWorkflow & {
+workflows: evict_caches: _base.#bashWorkflow & {
 	name: "Evict caches"
 
 	on: {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -34,7 +34,7 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	jobs: push: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,
 			json.#step & {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -23,7 +23,7 @@ import (
 // push_tip_to_trybot "syncs" active branches to the trybot repo.
 // Since the workflow is triggered by a push to any of the branches,
 // the step only needs to sync the pushed branch.
-push_tip_to_trybot: _base.#bashWorkflow & {
+workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -27,13 +27,13 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {
-		push: branches: _#protectedBranchPatterns
+		push: branches: core.protectedBranchPatterns
 	}
 
 	concurrency: "push_tip_to_trybot"
 
 	jobs: push: {
-		"runs-on": _#linuxMachine
+		"runs-on": core.linuxMachine
 		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -38,10 +38,10 @@ workflows: release: _base.#bashWorkflow & {
 
 	on: push: {
 		tags: [core.releaseTagPattern, "!" + core.zeroReleaseTagPattern]
-		branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
+		branches: list.Concat([[_base.#testDefaultBranch], core.protectedBranchPatterns])
 	}
 	jobs: goreleaser: {
-		"runs-on": _#linuxMachine
+		"runs-on": core.linuxMachine
 		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			for v in _base.#checkoutCode {v},
@@ -87,7 +87,7 @@ workflows: release: _base.#bashWorkflow & {
 			},
 			_base.#repositoryDispatch & {
 				name:           "Re-test cuelang.org"
-				if:             _#isReleaseTag
+				if:             _base.#isReleaseTag
 				#repositoryURL: "https://github.com/cue-lang/cuelang.org"
 				#arg: {
 					event_type: "Re-test post release of \(_#cueVersionRef)"
@@ -95,7 +95,7 @@ workflows: release: _base.#bashWorkflow & {
 			},
 			_base.#repositoryDispatch & {
 				name:           "Trigger unity build"
-				if:             _#isReleaseTag
+				if:             _base.#isReleaseTag
 				#repositoryURL: core.unityRepositoryURL
 				#arg: {
 					event_type: "Check against CUE \(_#cueVersionRef)"

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -37,16 +37,16 @@ workflows: release: _base.#bashWorkflow & {
 	concurrency: "release"
 
 	on: push: {
-		tags: [core.#releaseTagPattern, "!" + core.#zeroReleaseTagPattern]
+		tags: [core.releaseTagPattern, "!" + core.zeroReleaseTagPattern]
 		branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
 	}
 	jobs: goreleaser: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			for v in _base.#checkoutCode {v},
 			_base.#installGo & {
-				with: "go-version": core.#pinnedReleaseGo
+				with: "go-version": core.pinnedReleaseGo
 			},
 			json.#step & {
 				name: "Setup qemu"
@@ -74,7 +74,7 @@ workflows: release: _base.#bashWorkflow & {
 				uses: "goreleaser/goreleaser-action@v3"
 				with: {
 					"install-only": true
-					version:        core.#goreleaserVersion
+					version:        core.goreleaserVersion
 				}
 			},
 			json.#step & {
@@ -96,7 +96,7 @@ workflows: release: _base.#bashWorkflow & {
 			_base.#repositoryDispatch & {
 				name:           "Trigger unity build"
 				if:             _#isReleaseTag
-				#repositoryURL: core.#unityRepositoryURL
+				#repositoryURL: core.unityRepositoryURL
 				#arg: {
 					event_type: "Check against CUE \(_#cueVersionRef)"
 					client_payload: {

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -27,7 +27,7 @@ import (
 _#cueVersionRef: "${GITHUB_REF##refs/tags/}"
 
 // The release workflow
-release: _base.#bashWorkflow & {
+workflows: release: _base.#bashWorkflow & {
 
 	name: "Release"
 

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -23,10 +23,10 @@ import (
 workflows: tip_triggers: _base.#bashWorkflow & {
 
 	name: "Triggers on push to tip"
-	on: push: branches: [core.#defaultBranch]
+	on: push: branches: [core.defaultBranch]
 	jobs: push: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_base.#repositoryDispatch & {
 				name:           "Trigger tip.cuelang.org deploy"

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -25,7 +25,7 @@ workflows: tip_triggers: _base.#bashWorkflow & {
 	name: "Triggers on push to tip"
 	on: push: branches: [core.defaultBranch]
 	jobs: push: {
-		"runs-on": _#linuxMachine
+		"runs-on": core.linuxMachine
 		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_base.#repositoryDispatch & {

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -20,7 +20,7 @@ import (
 
 // The tip_triggers workflow. This fires for each new commit that hits the
 // default branch.
-tip_triggers: _base.#bashWorkflow & {
+workflows: tip_triggers: _base.#bashWorkflow & {
 
 	name: "Triggers on push to tip"
 	on: push: branches: [core.#defaultBranch]

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -24,14 +24,7 @@ import (
 
 // The trybot workflow.
 workflows: trybot: _base.#bashWorkflow & {
-	// Note: the name of this workflow is used by gerritstatusupdater as an
-	// identifier in the status updates that are posted as reviews for this
-	// workflows, but also as the result label key, e.g. "TryBot-Result" would
-	// be the result label key for the "TryBot" workflow. Note the result label
-	// key is therefore tied to the configuration of this repository.
-	//
-	// This name also shows up in the CI badge in the top-level README.
-	name: "TryBot"
+	name: _base.#trybot.name
 
 	on: {
 		push: {

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -23,7 +23,7 @@ import (
 )
 
 // The trybot workflow.
-trybot: _base.#bashWorkflow & {
+workflows: trybot: _base.#bashWorkflow & {
 	// Note: the name of this workflow is used by gerritstatusupdater as an
 	// identifier in the status updates that are posted as reviews for this
 	// workflows, but also as the result label key, e.g. "TryBot-Result" would

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -36,7 +36,7 @@ workflows: trybot: _base.#bashWorkflow & {
 	on: {
 		push: {
 			branches: list.Concat([["trybot/*/*", _base.#testDefaultBranch], _#protectedBranchPatterns]) // do not run PR branches
-			"tags-ignore": [core.#releaseTagPattern]
+			"tags-ignore": [core.releaseTagPattern]
 		}
 		pull_request: {}
 	}
@@ -78,7 +78,7 @@ workflows: trybot: _base.#bashWorkflow & {
 	}
 
 	_#pullThroughProxy: json.#step & {
-		name: "Pull this commit through the proxy on \(core.#defaultBranch)"
+		name: "Pull this commit through the proxy on \(core.defaultBranch)"
 		run: """
 			v=$(git rev-parse HEAD)
 			cd $(mktemp -d)

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -35,7 +35,7 @@ workflows: trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: list.Concat([["trybot/*/*", _base.#testDefaultBranch], _#protectedBranchPatterns]) // do not run PR branches
+			branches: list.Concat([["trybot/*/*", _base.#testDefaultBranch], core.protectedBranchPatterns]) // do not run PR branches
 			"tags-ignore": [core.releaseTagPattern]
 		}
 		pull_request: {}
@@ -47,7 +47,7 @@ workflows: trybot: _base.#bashWorkflow & {
 			"runs-on": "${{ matrix.os }}"
 
 			let goCaches = _base.#setupGoActionsCaches & {
-				#protectedBranchExpr: _#isProtectedBranch
+				#protectedBranchExpr: _base.#isProtectedBranch
 			}
 
 			steps: [
@@ -61,18 +61,18 @@ workflows: trybot: _base.#bashWorkflow & {
 				_base.#earlyChecks & {
 					// These checks don't vary based on the Go version or OS,
 					// so we only need to run them on one of the matrix jobs.
-					if: _#isLatestLinux
+					if: core.isLatestLinux
 				},
 				json.#step & {
-					if:  "\(_#isProtectedBranch) || \(_#isLatestLinux)"
+					if:  "\(_base.#isProtectedBranch) || \(core.isLatestLinux)"
 					run: "echo CUE_LONG=true >> $GITHUB_ENV"
 				},
 				_#goGenerate,
 				_#goTest & {
-					if: "\(_#isProtectedBranch) || !\(_#isLatestLinux)"
+					if: "\(_base.#isProtectedBranch) || !\(core.isLatestLinux)"
 				},
 				_#goTestRace & {
-					if: _#isLatestLinux
+					if: core.isLatestLinux
 				},
 				_#goCheck,
 				_base.#checkGitClean,
@@ -80,6 +80,14 @@ workflows: trybot: _base.#bashWorkflow & {
 
 				for v in goCaches.post {v},
 			]
+		}
+	}
+
+	_#testStrategy: {
+		"fail-fast": false
+		matrix: {
+			"go-version": ["1.18.x", core.latestStableGo]
+			os: [core.linuxMachine, core.macosMachine, core.windowsMachine]
 		}
 	}
 
@@ -116,7 +124,7 @@ workflows: trybot: _base.#bashWorkflow & {
 			echo "giving up after a number of retries"
 			exit 1
 			"""
-		if: "\(_#isProtectedBranch) && \(_#isLatestLinux)"
+		if: "\(_base.#isProtectedBranch) && \(core.isLatestLinux)"
 	}
 
 	_#goGenerate: json.#step & {
@@ -124,7 +132,7 @@ workflows: trybot: _base.#bashWorkflow & {
 		run:  "go generate ./..."
 		// The Go version corresponds to the precise version specified in
 		// the matrix. Skip windows for now until we work out why re-gen is flaky
-		if: _#isLatestLinux
+		if: core.isLatestLinux
 	}
 
 	_#goTest: json.#step & {
@@ -139,7 +147,7 @@ workflows: trybot: _base.#bashWorkflow & {
 		// dependencies that vary wildly between platforms.
 		// For now, to save CI resources, just run the checks on one matrix job.
 		// TODO: consider adding more checks as per https://github.com/golang/go/issues/42119.
-		if:   "\(_#isLatestLinux)"
+		if:   "\(core.isLatestLinux)"
 		name: "Check"
 		run:  "go vet ./..."
 	}

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -45,13 +45,18 @@ workflows: trybot: _base.#bashWorkflow & {
 		test: {
 			strategy:  _#testStrategy
 			"runs-on": "${{ matrix.os }}"
+
+			let goCaches = _base.#setupGoActionsCaches & {
+				#protectedBranchExpr: _#isProtectedBranch
+			}
+
 			steps: [
 				for v in _base.#checkoutCode {v},
 				_base.#installGo,
 
 				// cachePre must come after installing Node and Go, because the cache locations
 				// are established by running each tool.
-				for v in _#cachePre {v},
+				for v in goCaches.pre {v},
 
 				_base.#earlyChecks & {
 					// These checks don't vary based on the Go version or OS,
@@ -72,7 +77,8 @@ workflows: trybot: _base.#bashWorkflow & {
 				_#goCheck,
 				_base.#checkGitClean,
 				_#pullThroughProxy,
-				_#cachePost,
+
+				for v in goCaches.post {v},
 			]
 		}
 	}

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,6 @@
 package github
 
 // The trybot_dispatch workflow.
-trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
 	#type: _gerrithub.#dispatchTrybot
 }

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,4 @@
 package github
 
 // The trybot_dispatch workflow.
-workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
-	#type: _base.#trybot.key
-}
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#trybotWorkflow

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -16,5 +16,5 @@ package github
 
 // The trybot_dispatch workflow.
 workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
-	#type: _gerrithub.#dispatchTrybot
+	#type: _base.#trybot.key
 }

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -59,7 +59,7 @@ workflows: close({
 // This includes the default branch and release branches,
 // but excludes any others like feature branches or short-lived branches.
 // Note that #testDefaultBranch is excluded as it is GitHub-only.
-_#protectedBranchPatterns: [core.#defaultBranch, core.#releaseBranchPattern]
+_#protectedBranchPatterns: [core.defaultBranch, core.releaseBranchPattern]
 
 // _#matchPattern returns a GitHub Actions expression which evaluates whether a
 // variable matches a globbing pattern. For literal patterns it uses "==",
@@ -87,7 +87,7 @@ _#isProtectedBranch: "(" + strings.Join([ for branch in _#protectedBranchPattern
 	(_#matchPattern & {variable: "github.ref", pattern: "refs/heads/\(branch)"}).expr
 }], " || ") + ")"
 
-_#isReleaseTag: (_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(core.#releaseTagPattern)"}).expr
+_#isReleaseTag: (_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(core.releaseTagPattern)"}).expr
 
 _#linuxMachine:   "ubuntu-22.04"
 _#macosMachine:   "macos-11"
@@ -96,12 +96,12 @@ _#windowsMachine: "windows-2022"
 // _#isLatestLinux evaluates to true if the job is running on Linux with the
 // latest version of Go. This expression is often used to run certain steps
 // just once per CI workflow, to avoid duplicated work.
-_#isLatestLinux: "(matrix.go-version == '\(core.#latestStableGo)' && matrix.os == '\(_#linuxMachine)')"
+_#isLatestLinux: "(matrix.go-version == '\(core.latestStableGo)' && matrix.os == '\(_#linuxMachine)')"
 
 _#testStrategy: {
 	"fail-fast": false
 	matrix: {
-		"go-version": ["1.18.x", core.#latestStableGo]
+		"go-version": ["1.18.x", core.latestStableGo]
 		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
 	}
 }
@@ -109,7 +109,7 @@ _#testStrategy: {
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {
-	#repositoryURL:                      core.#githubRepositoryURL
+	#repositoryURL:                      core.githubRepositoryURL
 	#botGitHubUser:                      "cueckoo"
 	#botGitHubUserTokenSecretsKey:       "CUECKOO_GITHUB_PAT"
 	#botGitHubUserEmail:                 "cueckoo@gmail.com"
@@ -125,8 +125,8 @@ _gerrithub: gerrithub & {
 // Perhaps rename the import to something more obviously not intended to be
 // used, and then rename the field base?
 _base: base & {
-	#repositoryURL:                core.#githubRepositoryURL
-	#defaultBranch:                core.#defaultBranch
+	#repositoryURL:                core.githubRepositoryURL
+	#defaultBranch:                core.defaultBranch
 	#botGitHubUser:                "cueckoo"
 	#botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"
 }

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -25,41 +25,34 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-workflows: [...{file: string, schema: (json.#Workflow & {})}]
-workflows: [
-	{
-		// Note: the name of the file corresponds to the environment variable
-		// names for gerritstatusupdater. Therefore, this filename must only be
-		// change in combination with also updating the environment in which
-		// gerritstatusupdater is running for this repository.
-		//
-		// This name is also used by the CI badge in the top-level README.
-		//
-		// This name is also used in the evict_caches lookups.
-		file:   "trybot.yml"
-		schema: trybot
-	},
-	{
-		file:   "trybot_dispatch.yml"
-		schema: trybot_dispatch
-	},
-	{
-		file:   "release.yml"
-		schema: release
-	},
-	{
-		file:   "tip_triggers.yml"
-		schema: tip_triggers
-	},
-	{
-		file:   "push_tip_to_trybot.yml"
-		schema: push_tip_to_trybot
-	},
-	{
-		file:   "evict_caches.yml"
-		schema: evict_caches
-	},
-]
+// Note: the name of the workflows (and hence the corresponding .yml filenames)
+// correspond to the environment variable names for gerritstatusupdater.
+// Therefore, this filename must only be change in combination with also
+// updating the environment in which gerritstatusupdater is running for this
+// repository.
+//
+// This name is also used by the CI badge in the top-level README.
+//
+// This name is also used in the evict_caches lookups.
+//
+// i.e. don't change the names of workflows!
+//
+// In addition to separately declaring the workflows themselves, we define the
+// shape of #workflows here as a cross-check that we don't accidentally change
+// the name of workflows without reading this comment.
+//
+// We explicitly use close() here instead of a definition in order that we can
+// cue export the github package as a test.
+workflows: close({
+	[string]: json.#Workflow
+
+	trybot:             _
+	trybot_dispatch:    _
+	release:            _
+	tip_triggers:       _
+	push_tip_to_trybot: _
+	evict_caches:       _
+})
 
 // _#protectedBranchPatterns is a list of glob patterns to match the protected
 // git branches which are continuously used during development on Gerrit.

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -44,18 +44,19 @@ import (
 workflows: close({
 	[string]: json.#Workflow
 
-	trybot:             _
-	trybot_dispatch:    _
-	release:            _
-	tip_triggers:       _
-	push_tip_to_trybot: _
-	evict_caches:       _
+	(_base.#trybot.key): _
+	trybot_dispatch:     _
+	release:             _
+	tip_triggers:        _
+	push_tip_to_trybot:  _
+	evict_caches:        _
 })
 
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {
 	#repositoryURL:                      core.githubRepositoryURL
+	#trybotKey:                          _base.#trybot.key
 	#botGitHubUser:                      "cueckoo"
 	#botGitHubUserTokenSecretsKey:       "CUECKOO_GITHUB_PAT"
 	#botGitHubUserEmail:                 "cueckoo@gmail.com"

--- a/internal/ci/goreleaser/goreleaser_tool.cue
+++ b/internal/ci/goreleaser/goreleaser_tool.cue
@@ -58,9 +58,9 @@ command: release: {
 		"goreleaser", "release", "-f", "-", "--rm-dist",
 
 		// Only run the full release when running on GitHub actions for a release tag.
-		// Keep in sync with core.#releaseTagPattern, which is a globbing pattern
+		// Keep in sync with core.releaseTagPattern, which is a globbing pattern
 		// rather than a regular expression.
-		if _githubRef !~ "refs/tags/\(core.#releaseTagPrefix).*" {
+		if _githubRef !~ "refs/tags/\(core.releaseTagPrefix).*" {
 			"--snapshot"
 		},
 	]


### PR DESCRIPTION
- internal/ci: refactor the way we declare workflows
- internal/ci: improve core package docs
- internal/ci: move core package away from definitions
- internal/ci: move core.#codeReview to base
- internal/ci: move core._#URLPath to base
- internal/ci: improve base package docs
- internal/ci: hoist cache steps to base package
- internal/ci: move workflows.cue defs to better places
- internal/ci: hoist dispatch keys to base
- internal/ci: rename gerrithub #dispatchWorkflow to #trybotWorkflow
