### PR TITLE
trybot/Ic0f76cbd3d310b98b8d9de08810098ed6daee88b/8f608c028119aafe9dcc14f8ad31f2c1ef28062b/551363/5

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -165,4 +165,3 @@ jobs:
 
           echo "giving up after a number of retries"
           exit 1
-      - run: find '${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download' '${{ steps.go-cache-dir.outputs.dir }}' -type f -amin +7200 -delete -print

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -73,13 +73,50 @@ jobs:
           # recently. Increase it to 5 or 10 soon, to also cover CL chains.
           for commit in $(git rev-list --max-count=1 HEAD); do
           	if ! git rev-list --format=%B --max-count=1 $commit | grep -q '^Signed-off-by:'; then
-          		echo -e "
-          Recent commit is lacking Signed-off-by:
-          "
+          		echo -e "\nRecent commit is lacking Signed-off-by:\n"
           		git show --quiet $commit
           		exit 1
           	fi
           done
+
+          # Ensure that commit messages have a blank second line.
+          # We know that a commit message must be longer than a single
+          # line because each commit must be signed-off.
+          if git log --format=%B -n 1 HEAD | sed -n '2{/^$/{q1}}'; then
+          	echo "second line of commit message must be blank"
+          	exit 1
+          fi
+
+          # Ensure that the commit author is the same as the signed-off-by.  This
+          # is a basic requirement of DCO. It is enforced by Gerrit (although
+          # noting that in Gerrit the author name does not have to match, only
+          # the email address), but _not_ by the DCO GitHub app:
+          #
+          #   https://github.com/dcoapp/app/issues/201
+          #
+          # Provide a sanity check as part of GitHub workflows that should enforce
+          # this, e.g. trybot workflows.
+          #
+          # We do so by comparing the commit author and "Signed-off-by" trailer for
+          # strict equality. Whilst this is more strict than Gerrit, it should
+          # generally be the case, and we can always relax this when presented with
+          # specific situations where it is is a problem.
+
+          # commit author email address
+          commitauthor="$(git log -1 --pretty="%ae")"
+
+          # signed-off-by trailer email address. There is no way to parse just the
+          # email address from the trailer in the same way as git log, so instead
+          # grab the relevant trailer and then take the last whitespace-delimited
+          # part as the "<>" contained email address.
+          # Getting the Signed-off-by trailer in this way causes blank
+          # lines for some reason. Use awk to remove them.
+          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
+
+          if [[ "$commitauthor" != "$commitsigner" ]]; then
+          	echo "commit author email address does not match signed-off-by trailer"
+          	exit 1
+          fi
       - if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-branch.')) || (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-22.04')
         run: echo CUE_LONG=true >> $GITHUB_ENV
       - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-22.04')

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -84,7 +84,7 @@ import (
 
 #earlyChecks: json.#step & {
 	name: "Early git and code sanity checks"
-	run: """
+	run: #"""
 		# Ensure the recent commit messages have Signed-off-by headers.
 		# TODO: Remove once this is enforced for admins too;
 		# see https://bugs.chromium.org/p/gerrit/issues/detail?id=15229
@@ -97,7 +97,46 @@ import (
 				exit 1
 			fi
 		done
-		"""
+
+		# Ensure that commit messages have a blank second line.
+		# We know that a commit message must be longer than a single
+		# line because each commit must be signed-off.
+		if git log --format=%B -n 1 HEAD | sed -n '2{/^$/{q1}}'; then
+			echo "second line of commit message must be blank"
+			exit 1
+		fi
+
+		# Ensure that the commit author is the same as the signed-off-by.  This
+		# is a basic requirement of DCO. It is enforced by Gerrit (although
+		# noting that in Gerrit the author name does not have to match, only
+		# the email address), but _not_ by the DCO GitHub app:
+		#
+		#   https://github.com/dcoapp/app/issues/201
+		#
+		# Provide a sanity check as part of GitHub workflows that should enforce
+		# this, e.g. trybot workflows.
+		#
+		# We do so by comparing the commit author and "Signed-off-by" trailer for
+		# strict equality. Whilst this is more strict than Gerrit, it should
+		# generally be the case, and we can always relax this when presented with
+		# specific situations where it is is a problem.
+
+		# commit author email address
+		commitauthor="$(git log -1 --pretty="%ae")"
+
+		# signed-off-by trailer email address. There is no way to parse just the
+		# email address from the trailer in the same way as git log, so instead
+		# grab the relevant trailer and then take the last whitespace-delimited
+		# part as the "<>" contained email address.
+		# Getting the Signed-off-by trailer in this way causes blank
+		# lines for some reason. Use awk to remove them.
+		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
+
+		if [[ "$commitauthor" != "$commitsigner" ]]; then
+			echo "commit author email address does not match signed-off-by trailer"
+			exit 1
+		fi
+		"""#
 }
 
 #checkGitClean: json.#step & {

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -39,12 +39,13 @@ _goos: string @tag(os,var=os)
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
 command: gen: workflows: {
-	for w in github.workflows {
-		"\(w.file)": file.Create & {
+	for _workflowName, _workflow in github.workflows {
+		let _filename = _workflowName + ".yml"
+		(_filename): file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
-			filename: path.Join([_dir, w.file], _goos)
+			filename: path.Join([_dir, _filename], _goos)
 			let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
-			contents: "# \(donotedit)\n\n\(yaml.Marshal(w.schema))"
+			contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
 		}
 	}
 }

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -42,7 +42,7 @@ import (
 //
 // In testing with @mvdan, this resulted in cache sizes for Linux dropping from
 // ~1GB to ~125MB. This is a considerable saving.
-evict_caches: _base.#bashWorkflow & {
+workflows: evict_caches: _base.#bashWorkflow & {
 	name: "Evict caches"
 
 	on: {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -23,7 +23,7 @@ import (
 // push_tip_to_trybot "syncs" active branches to the trybot repo.
 // Since the workflow is triggered by a push to any of the branches,
 // the step only needs to sync the pushed branch.
-push_tip_to_trybot: _base.#bashWorkflow & {
+workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -27,7 +27,7 @@ import (
 _#cueVersionRef: "${GITHUB_REF##refs/tags/}"
 
 // The release workflow
-release: _base.#bashWorkflow & {
+workflows: release: _base.#bashWorkflow & {
 
 	name: "Release"
 

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -20,7 +20,7 @@ import (
 
 // The tip_triggers workflow. This fires for each new commit that hits the
 // default branch.
-tip_triggers: _base.#bashWorkflow & {
+workflows: tip_triggers: _base.#bashWorkflow & {
 
 	name: "Triggers on push to tip"
 	on: push: branches: [core.#defaultBranch]

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -72,7 +72,6 @@ trybot: _base.#bashWorkflow & {
 				_#goCheck,
 				_base.#checkGitClean,
 				_#pullThroughProxy,
-				_#cachePost,
 			]
 		}
 	}

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -23,7 +23,7 @@ import (
 )
 
 // The trybot workflow.
-trybot: _base.#bashWorkflow & {
+workflows: trybot: _base.#bashWorkflow & {
 	// Note: the name of this workflow is used by gerritstatusupdater as an
 	// identifier in the status updates that are posted as reviews for this
 	// workflows, but also as the result label key, e.g. "TryBot-Result" would

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,6 @@
 package github
 
 // The trybot_dispatch workflow.
-trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
 	#type: _gerrithub.#dispatchTrybot
 }

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -175,8 +175,3 @@ _#cachePre: [
 		}
 	},
 ]
-
-_#cachePost: json.#step & {
-	let qCacheDirs = [ for v in _#cacheDirs {"'\(v)'"}]
-	run: "find \(strings.Join(qCacheDirs, " ")) -type f -amin +7200 -delete -print"
-}

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -25,41 +25,34 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-workflows: [...{file: string, schema: (json.#Workflow & {})}]
-workflows: [
-	{
-		// Note: the name of the file corresponds to the environment variable
-		// names for gerritstatusupdater. Therefore, this filename must only be
-		// change in combination with also updating the environment in which
-		// gerritstatusupdater is running for this repository.
-		//
-		// This name is also used by the CI badge in the top-level README.
-		//
-		// This name is also used in the evict_caches lookups.
-		file:   "trybot.yml"
-		schema: trybot
-	},
-	{
-		file:   "trybot_dispatch.yml"
-		schema: trybot_dispatch
-	},
-	{
-		file:   "release.yml"
-		schema: release
-	},
-	{
-		file:   "tip_triggers.yml"
-		schema: tip_triggers
-	},
-	{
-		file:   "push_tip_to_trybot.yml"
-		schema: push_tip_to_trybot
-	},
-	{
-		file:   "evict_caches.yml"
-		schema: evict_caches
-	},
-]
+// Note: the name of the workflows (and hence the corresponding .yml filenames)
+// correspond to the environment variable names for gerritstatusupdater.
+// Therefore, this filename must only be change in combination with also
+// updating the environment in which gerritstatusupdater is running for this
+// repository.
+//
+// This name is also used by the CI badge in the top-level README.
+//
+// This name is also used in the evict_caches lookups.
+//
+// i.e. don't change the names of workflows!
+//
+// In addition to separately declaring the workflows themselves, we define the
+// shape of #workflows here as a cross-check that we don't accidentally change
+// the name of workflows without reading this comment.
+//
+// We explicitly use close() here instead of a definition in order that we can
+// cue export the github package as a test.
+workflows: close({
+	[string]: json.#Workflow
+
+	trybot:             _
+	trybot_dispatch:    _
+	release:            _
+	tip_triggers:       _
+	push_tip_to_trybot: _
+	evict_caches:       _
+})
 
 // _#protectedBranchPatterns is a list of glob patterns to match the protected
 // git branches which are continuously used during development on Gerrit.

--- a/internal/ci/vendor/vendor_tool.cue
+++ b/internal/ci/vendor/vendor_tool.cue
@@ -26,7 +26,7 @@ import (
 // project which "vendors" the various workflow-related
 // packages can specify "cue" as the value so that unity
 // tests can specify the cmd/cue binary to use.
-_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.2" @tag(cue_cmd)
+_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.5" @tag(cue_cmd)
 
 // For the commands below, note we use simple yet hacky path resolution, rather
 // than anything that might derive the module root using go list or similar, in


### PR DESCRIPTION
- internal/ci: update base early git checks from alpha.cuelang.org
- internal/ci: bump default of cue version to v0.5.0-beta.5
- internal/ci: remove the cachePost steps
- internal/ci: refactor the way we declare workflows
