### PR TITLE
trybot/Ie015dff76626c9166d5b911233761745544f5510/7a8eda2315df007ad6114b5679d92b91f75f7337/551379/8

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -75,13 +75,50 @@ jobs:
           # recently. Increase it to 5 or 10 soon, to also cover CL chains.
           for commit in $(git rev-list --max-count=1 HEAD); do
           	if ! git rev-list --format=%B --max-count=1 $commit | grep -q '^Signed-off-by:'; then
-          		echo -e "
-          Recent commit is lacking Signed-off-by:
-          "
+          		echo -e "\nRecent commit is lacking Signed-off-by:\n"
           		git show --quiet $commit
           		exit 1
           	fi
           done
+
+          # Ensure that commit messages have a blank second line.
+          # We know that a commit message must be longer than a single
+          # line because each commit must be signed-off.
+          if git log --format=%B -n 1 HEAD | sed -n '2{/^$/{q1}}'; then
+          	echo "second line of commit message must be blank"
+          	exit 1
+          fi
+
+          # Ensure that the commit author is the same as the signed-off-by.  This
+          # is a basic requirement of DCO. It is enforced by Gerrit (although
+          # noting that in Gerrit the author name does not have to match, only
+          # the email address), but _not_ by the DCO GitHub app:
+          #
+          #   https://github.com/dcoapp/app/issues/201
+          #
+          # Provide a sanity check as part of GitHub workflows that should enforce
+          # this, e.g. trybot workflows.
+          #
+          # We do so by comparing the commit author and "Signed-off-by" trailer for
+          # strict equality. Whilst this is more strict than Gerrit, it should
+          # generally be the case, and we can always relax this when presented with
+          # specific situations where it is is a problem.
+
+          # commit author email address
+          commitauthor="$(git log -1 --pretty="%ae")"
+
+          # signed-off-by trailer email address. There is no way to parse just the
+          # email address from the trailer in the same way as git log, so instead
+          # grab the relevant trailer and then take the last whitespace-delimited
+          # part as the "<>" contained email address.
+          # Getting the Signed-off-by trailer in this way causes blank
+          # lines for some reason. Use awk to remove them.
+          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
+
+          if [[ "$commitauthor" != "$commitsigner" ]]; then
+          	echo "commit author email address does not match signed-off-by trailer"
+          	exit 1
+          fi
       - if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-branch.')) || (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-22.04')
         run: echo CUE_LONG=true >> $GITHUB_ENV
       - if: (matrix.go-version == '1.19.x' && matrix.os == 'ubuntu-22.04')

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -167,4 +167,3 @@ jobs:
 
           echo "giving up after a number of retries"
           exit 1
-      - run: find '${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download' '${{ steps.go-cache-dir.outputs.dir }}' -type f -amin +7200 -delete -print

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -167,3 +167,23 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 #curlGitHubAPI: #"""
 	curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.\#(#botGitHubUserTokenSecretsKey) }}" -H "X-GitHub-Api-Version: 2022-11-28"
 	"""#
+
+// #codeReview defines the schema of a codereview.cfg file that
+// sits at the root of a repository. codereview.cfg is the configuration
+// file that drives golang.org/x/review/git-codereview. This config
+// file is also used by github.com/cue-sh/tools/cmd/cueckoo.
+#codeReview: {
+	gerrit?:      string
+	github?:      string
+	"cue-unity"?: string
+}
+
+// #toCodeReviewCfg converts a #codeReview instance to
+// the key: value
+#toCodeReviewCfg: {
+	#input: #codeReview
+	let parts = [ for k, v in #input {k + ": " + v}]
+
+	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
+	strings.Join(parts, "\n")
+}

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -17,6 +17,7 @@
 package base
 
 import (
+	"list"
 	"strings"
 	"path"
 	"strconv"
@@ -186,4 +187,13 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 
 	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
 	strings.Join(parts, "\n")
+}
+
+// #URLPath is a temporary measure to derive the path part of a URL.
+//
+// TODO: remove when cuelang.org/issue/1433 lands.
+#URLPath: {
+	#url: string
+	let parts = strings.Split(#url, "/")
+	strings.Join(list.Slice(parts, 3, len(parts)), "/")
 }

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -84,7 +84,7 @@ import (
 
 #earlyChecks: json.#step & {
 	name: "Early git and code sanity checks"
-	run: """
+	run: #"""
 		# Ensure the recent commit messages have Signed-off-by headers.
 		# TODO: Remove once this is enforced for admins too;
 		# see https://bugs.chromium.org/p/gerrit/issues/detail?id=15229
@@ -97,7 +97,46 @@ import (
 				exit 1
 			fi
 		done
-		"""
+
+		# Ensure that commit messages have a blank second line.
+		# We know that a commit message must be longer than a single
+		# line because each commit must be signed-off.
+		if git log --format=%B -n 1 HEAD | sed -n '2{/^$/{q1}}'; then
+			echo "second line of commit message must be blank"
+			exit 1
+		fi
+
+		# Ensure that the commit author is the same as the signed-off-by.  This
+		# is a basic requirement of DCO. It is enforced by Gerrit (although
+		# noting that in Gerrit the author name does not have to match, only
+		# the email address), but _not_ by the DCO GitHub app:
+		#
+		#   https://github.com/dcoapp/app/issues/201
+		#
+		# Provide a sanity check as part of GitHub workflows that should enforce
+		# this, e.g. trybot workflows.
+		#
+		# We do so by comparing the commit author and "Signed-off-by" trailer for
+		# strict equality. Whilst this is more strict than Gerrit, it should
+		# generally be the case, and we can always relax this when presented with
+		# specific situations where it is is a problem.
+
+		# commit author email address
+		commitauthor="$(git log -1 --pretty="%ae")"
+
+		# signed-off-by trailer email address. There is no way to parse just the
+		# email address from the trailer in the same way as git log, so instead
+		# grab the relevant trailer and then take the last whitespace-delimited
+		# part as the "<>" contained email address.
+		# Getting the Signed-off-by trailer in this way causes blank
+		# lines for some reason. Use awk to remove them.
+		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
+
+		if [[ "$commitauthor" != "$commitsigner" ]]; then
+			echo "commit author email address does not match signed-off-by trailer"
+			exit 1
+		fi
+		"""#
 }
 
 #checkGitClean: json.#step & {

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -39,12 +39,13 @@ _goos: string @tag(os,var=os)
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
 command: gen: workflows: {
-	for w in github.workflows {
-		"\(w.file)": file.Create & {
+	for _workflowName, _workflow in github.workflows {
+		let _filename = _workflowName + ".yml"
+		(_filename): file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
-			filename: path.Join([_dir, w.file], _goos)
+			filename: path.Join([_dir, _filename], _goos)
 			let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
-			contents: "# \(donotedit)\n\n\(yaml.Marshal(w.schema))"
+			contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
 		}
 	}
 }

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -53,7 +53,7 @@ command: gen: workflows: {
 command: gen: codereviewcfg: file.Create & {
 	_dir:     path.FromSlash("../../", path.Unix)
 	filename: path.Join([_dir, "codereview.cfg"], _goos)
-	let res = core.#toCodeReviewCfg & {#input: core.codeReview, _}
+	let res = base.#toCodeReviewCfg & {#input: core.codeReview, _}
 	let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
 	contents: "# \(donotedit)\n\n\(res)\n"
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -9,10 +9,10 @@ import (
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
-#githubRepositoryURL:  "https://github.com/cue-lang/cue"
-#gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
-#githubRepositoryPath: _#URLPath & {#url: #githubRepositoryURL, _}
-#unityRepositoryURL:   "https://github.com/cue-unity/unity"
+githubRepositoryURL:  "https://github.com/cue-lang/cue"
+gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
+githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
+unityRepositoryURL:   "https://github.com/cue-unity/unity"
 
 // Not ideal, but hack together something that gives us the path
 // of a URL. In lieu of cuelang.org/issue/1433
@@ -24,34 +24,34 @@ _#URLPath: {
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.
-#latestStableGo: "1.19.x"
+latestStableGo: "1.19.x"
 
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#pinnedReleaseGo: "1.19.7"
+pinnedReleaseGo: "1.19.7"
 
-#goreleaserVersion: "v1.13.1"
+goreleaserVersion: "v1.13.1"
 
-#defaultBranch: "master"
+defaultBranch: "master"
 
-// #releaseBranchPrefix is the git branch name prefix used to identify
+// releaseBranchPrefix is the git branch name prefix used to identify
 // release branches.
-#releaseBranchPrefix: "release-branch."
+releaseBranchPrefix: "release-branch."
 
-// #releaseBranchPattern is the GitHub pattern that corresponds to
-// #releaseBranchPrefix.
-#releaseBranchPattern: #releaseBranchPrefix + "*"
+// releaseBranchPattern is the GitHub pattern that corresponds to
+// releaseBranchPrefix.
+releaseBranchPattern: releaseBranchPrefix + "*"
 
-// #releaseTagPrefix is the prefix used to identify all git tag that correspond
+// releaseTagPrefix is the prefix used to identify all git tag that correspond
 // to semver releases
-#releaseTagPrefix: "v"
+releaseTagPrefix: "v"
 
-// #releaseTagPattern is the GitHub glob pattern that corresponds to
-// #releaseTagPrefix.
-#releaseTagPattern: #releaseTagPrefix + "*"
+// releaseTagPattern is the GitHub glob pattern that corresponds to
+// releaseTagPrefix.
+releaseTagPattern: releaseTagPrefix + "*"
 
-// #zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
+// zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
 // When we create a release branch for v0.$X.0, it's likely that commits on the
 // default branch will from that point onwards be intended for the $X+1
 // version. However, unless we tag the next commit after the release branch, it
@@ -61,11 +61,11 @@ _#URLPath: {
 // A "zero" tag fixes this when applied to the first commit after a release
 // branch. Critically, the -0.dev pre-release suffix is ordered before -alpha.
 // tags.
-#zeroReleaseTagSuffix: "-0.dev"
+zeroReleaseTagSuffix: "-0.dev"
 
-// #zeroReleaseTagPattern is the GitHub glob pattern that corresponds
-// #zeroReleaseTagSuffix.
-#zeroReleaseTagPattern: "*" + #zeroReleaseTagSuffix
+// zeroReleaseTagPattern is the GitHub glob pattern that corresponds
+// zeroReleaseTagSuffix.
+zeroReleaseTagPattern: "*" + zeroReleaseTagSuffix
 
 #codeReview: {
 	gerrit?:      string
@@ -74,9 +74,9 @@ _#URLPath: {
 }
 
 codeReview: #codeReview & {
-	github:      #githubRepositoryURL
-	gerrit:      #gerritRepositoryURL
-	"cue-unity": #unityRepositoryURL
+	github:      githubRepositoryURL
+	gerrit:      gerritRepositoryURL
+	"cue-unity": unityRepositoryURL
 }
 
 // #toCodeReviewCfg converts a #codeReview instance to

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -1,3 +1,6 @@
+// package core contains data values that are commont to all CUE
+// configurations.  This not only includes GitHub workflows, but also things
+// like gerrit configuration etc.
 package core
 
 import (

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -6,6 +6,8 @@ package core
 import (
 	"list"
 	"strings"
+
+	"cuelang.org/go/internal/ci/base"
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
@@ -67,24 +69,8 @@ zeroReleaseTagSuffix: "-0.dev"
 // zeroReleaseTagSuffix.
 zeroReleaseTagPattern: "*" + zeroReleaseTagSuffix
 
-#codeReview: {
-	gerrit?:      string
-	github?:      string
-	"cue-unity"?: string
-}
-
-codeReview: #codeReview & {
+codeReview: base.#codeReview & {
 	github:      githubRepositoryURL
 	gerrit:      gerritRepositoryURL
 	"cue-unity": unityRepositoryURL
-}
-
-// #toCodeReviewCfg converts a #codeReview instance to
-// the key: value
-#toCodeReviewCfg: {
-	#input: #codeReview
-	let parts = [ for k, v in #input {k + ": " + v}]
-
-	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
-	strings.Join(parts, "\n")
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -4,25 +4,14 @@
 package core
 
 import (
-	"list"
-	"strings"
-
 	"cuelang.org/go/internal/ci/base"
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
 githubRepositoryURL:  "https://github.com/cue-lang/cue"
 gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cue"
-githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
+githubRepositoryPath: base.#URLPath & {#url: githubRepositoryURL, _}
 unityRepositoryURL:   "https://github.com/cue-unity/unity"
-
-// Not ideal, but hack together something that gives us the path
-// of a URL. In lieu of cuelang.org/issue/1433
-_#URLPath: {
-	#url: string
-	let parts = strings.Split(#url, "/")
-	strings.Join(list.Slice(parts, 3, len(parts)), "/")
-}
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -54,7 +54,7 @@ workflows: evict_caches: _base.#bashWorkflow & {
 	jobs: {
 		test: {
 			// We only want to run this in the main repo
-			if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+			if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 			"runs-on": _#linuxMachine
 			steps: [
 				json.#step & {
@@ -77,7 +77,7 @@ workflows: evict_caches: _base.#bashWorkflow & {
 
 						echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
 						gh extension install actions/gh-actions-cache
-						for i in \(core.#githubRepositoryURL) \(core.#githubRepositoryURL)-trybot
+						for i in \(core.githubRepositoryURL) \(core.githubRepositoryURL)-trybot
 						do
 							echo "Evicting caches for $i"
 							cd $(mktemp -d)
@@ -92,7 +92,7 @@ workflows: evict_caches: _base.#bashWorkflow & {
 						# Now trigger the most recent workflow run on each of the default branches.
 						# We do this by listing all the branches on the main repo and finding those
 						# which match the protected branch patterns (globs).
-						for j in $(\(_base.#curlGitHubAPI) -f https://api.github.com/repos/\(core.#githubRepositoryPath)/branches | jq -r '.[] | .name')
+						for j in $(\(_base.#curlGitHubAPI) -f https://api.github.com/repos/\(core.githubRepositoryPath)/branches | jq -r '.[] | .name')
 						do
 							for i in \(branchPatterns)
 							do
@@ -101,8 +101,8 @@ workflows: evict_caches: _base.#bashWorkflow & {
 								fi
 
 								echo "$j is a match with $i"
-								\(rerunLatestWorkflow & {#repo: core.#githubRepositoryPath, #branch: "$j", _})
-								\(rerunLatestWorkflow & {#repo: core.#githubRepositoryPath + "-trybot", #branch: "$j", _})
+								\(rerunLatestWorkflow & {#repo: core.githubRepositoryPath, #branch: "$j", _})
+								\(rerunLatestWorkflow & {#repo: core.githubRepositoryPath + "-trybot", #branch: "$j", _})
 							done
 						done
 						"""

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -42,7 +42,7 @@ import (
 //
 // In testing with @mvdan, this resulted in cache sizes for Linux dropping from
 // ~1GB to ~125MB. This is a considerable saving.
-evict_caches: _base.#bashWorkflow & {
+workflows: evict_caches: _base.#bashWorkflow & {
 	name: "Evict caches"
 
 	on: {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -34,7 +34,7 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	jobs: push: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,
 			json.#step & {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -23,7 +23,7 @@ import (
 // push_tip_to_trybot "syncs" active branches to the trybot repo.
 // Since the workflow is triggered by a push to any of the branches,
 // the step only needs to sync the pushed branch.
-push_tip_to_trybot: _base.#bashWorkflow & {
+workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -37,16 +37,16 @@ workflows: release: _base.#bashWorkflow & {
 	concurrency: "release"
 
 	on: push: {
-		tags: [core.#releaseTagPattern, "!" + core.#zeroReleaseTagPattern]
+		tags: [core.releaseTagPattern, "!" + core.zeroReleaseTagPattern]
 		branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
 	}
 	jobs: goreleaser: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			for v in _base.#checkoutCode {v},
 			_base.#installGo & {
-				with: "go-version": core.#pinnedReleaseGo
+				with: "go-version": core.pinnedReleaseGo
 			},
 			json.#step & {
 				name: "Setup qemu"
@@ -74,7 +74,7 @@ workflows: release: _base.#bashWorkflow & {
 				uses: "goreleaser/goreleaser-action@v3"
 				with: {
 					"install-only": true
-					version:        core.#goreleaserVersion
+					version:        core.goreleaserVersion
 				}
 			},
 			json.#step & {
@@ -96,7 +96,7 @@ workflows: release: _base.#bashWorkflow & {
 			_base.#repositoryDispatch & {
 				name:           "Trigger unity build"
 				if:             _#isReleaseTag
-				#repositoryURL: core.#unityRepositoryURL
+				#repositoryURL: core.unityRepositoryURL
 				#arg: {
 					event_type: "Check against CUE \(_#cueVersionRef)"
 					client_payload: {

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -27,7 +27,7 @@ import (
 _#cueVersionRef: "${GITHUB_REF##refs/tags/}"
 
 // The release workflow
-release: _base.#bashWorkflow & {
+workflows: release: _base.#bashWorkflow & {
 
 	name: "Release"
 

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -23,10 +23,10 @@ import (
 workflows: tip_triggers: _base.#bashWorkflow & {
 
 	name: "Triggers on push to tip"
-	on: push: branches: [core.#defaultBranch]
+	on: push: branches: [core.defaultBranch]
 	jobs: push: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_base.#repositoryDispatch & {
 				name:           "Trigger tip.cuelang.org deploy"

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -20,7 +20,7 @@ import (
 
 // The tip_triggers workflow. This fires for each new commit that hits the
 // default branch.
-tip_triggers: _base.#bashWorkflow & {
+workflows: tip_triggers: _base.#bashWorkflow & {
 
 	name: "Triggers on push to tip"
 	on: push: branches: [core.#defaultBranch]

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -82,7 +82,6 @@ trybot: _base.#bashWorkflow & {
 				_#goCheck,
 				_base.#checkGitClean,
 				_#pullThroughProxy,
-				_#cachePost,
 			]
 		}
 	}

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -23,7 +23,7 @@ import (
 )
 
 // The trybot workflow.
-trybot: _base.#bashWorkflow & {
+workflows: trybot: _base.#bashWorkflow & {
 	// Note: the name of this workflow is used by gerritstatusupdater as an
 	// identifier in the status updates that are posted as reviews for this
 	// workflows, but also as the result label key, e.g. "TryBot-Result" would

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -36,7 +36,7 @@ workflows: trybot: _base.#bashWorkflow & {
 	on: {
 		push: {
 			branches: list.Concat([["trybot/*/*", _base.#testDefaultBranch], _#protectedBranchPatterns]) // do not run PR branches
-			"tags-ignore": [core.#releaseTagPattern]
+			"tags-ignore": [core.releaseTagPattern]
 		}
 		pull_request: {}
 	}
@@ -87,7 +87,7 @@ workflows: trybot: _base.#bashWorkflow & {
 	}
 
 	_#pullThroughProxy: json.#step & {
-		name: "Pull this commit through the proxy on \(core.#defaultBranch)"
+		name: "Pull this commit through the proxy on \(core.defaultBranch)"
 		run: """
 			v=$(git rev-parse HEAD)
 			cd $(mktemp -d)

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,6 @@
 package github
 
 // The trybot_dispatch workflow.
-trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
 	#type: _gerrithub.#dispatchTrybot
 }

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -175,8 +175,3 @@ _#cachePre: [
 		}
 	},
 ]
-
-_#cachePost: json.#step & {
-	let qCacheDirs = [ for v in _#cacheDirs {"'\(v)'"}]
-	run: "find \(strings.Join(qCacheDirs, " ")) -type f -amin +7200 -delete -print"
-}

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -59,7 +59,7 @@ workflows: close({
 // This includes the default branch and release branches,
 // but excludes any others like feature branches or short-lived branches.
 // Note that #testDefaultBranch is excluded as it is GitHub-only.
-_#protectedBranchPatterns: [core.#defaultBranch, core.#releaseBranchPattern]
+_#protectedBranchPatterns: [core.defaultBranch, core.releaseBranchPattern]
 
 // _#matchPattern returns a GitHub Actions expression which evaluates whether a
 // variable matches a globbing pattern. For literal patterns it uses "==",
@@ -87,7 +87,7 @@ _#isProtectedBranch: "(" + strings.Join([ for branch in _#protectedBranchPattern
 	(_#matchPattern & {variable: "github.ref", pattern: "refs/heads/\(branch)"}).expr
 }], " || ") + ")"
 
-_#isReleaseTag: (_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(core.#releaseTagPattern)"}).expr
+_#isReleaseTag: (_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(core.releaseTagPattern)"}).expr
 
 _#linuxMachine:   "ubuntu-22.04"
 _#macosMachine:   "macos-11"
@@ -96,12 +96,12 @@ _#windowsMachine: "windows-2022"
 // _#isLatestLinux evaluates to true if the job is running on Linux with the
 // latest version of Go. This expression is often used to run certain steps
 // just once per CI workflow, to avoid duplicated work.
-_#isLatestLinux: "(matrix.go-version == '\(core.#latestStableGo)' && matrix.os == '\(_#linuxMachine)')"
+_#isLatestLinux: "(matrix.go-version == '\(core.latestStableGo)' && matrix.os == '\(_#linuxMachine)')"
 
 _#testStrategy: {
 	"fail-fast": false
 	matrix: {
-		"go-version": ["1.18.x", core.#latestStableGo]
+		"go-version": ["1.18.x", core.latestStableGo]
 		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
 	}
 }
@@ -109,7 +109,7 @@ _#testStrategy: {
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {
-	#repositoryURL:                      core.#githubRepositoryURL
+	#repositoryURL:                      core.githubRepositoryURL
 	#botGitHubUser:                      "cueckoo"
 	#botGitHubUserTokenSecretsKey:       "CUECKOO_GITHUB_PAT"
 	#botGitHubUserEmail:                 "cueckoo@gmail.com"
@@ -125,8 +125,8 @@ _gerrithub: gerrithub & {
 // Perhaps rename the import to something more obviously not intended to be
 // used, and then rename the field base?
 _base: base & {
-	#repositoryURL:                core.#githubRepositoryURL
-	#defaultBranch:                core.#defaultBranch
+	#repositoryURL:                core.githubRepositoryURL
+	#defaultBranch:                core.defaultBranch
 	#botGitHubUser:                "cueckoo"
 	#botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"
 }

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -25,41 +25,34 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-workflows: [...{file: string, schema: (json.#Workflow & {})}]
-workflows: [
-	{
-		// Note: the name of the file corresponds to the environment variable
-		// names for gerritstatusupdater. Therefore, this filename must only be
-		// change in combination with also updating the environment in which
-		// gerritstatusupdater is running for this repository.
-		//
-		// This name is also used by the CI badge in the top-level README.
-		//
-		// This name is also used in the evict_caches lookups.
-		file:   "trybot.yml"
-		schema: trybot
-	},
-	{
-		file:   "trybot_dispatch.yml"
-		schema: trybot_dispatch
-	},
-	{
-		file:   "release.yml"
-		schema: release
-	},
-	{
-		file:   "tip_triggers.yml"
-		schema: tip_triggers
-	},
-	{
-		file:   "push_tip_to_trybot.yml"
-		schema: push_tip_to_trybot
-	},
-	{
-		file:   "evict_caches.yml"
-		schema: evict_caches
-	},
-]
+// Note: the name of the workflows (and hence the corresponding .yml filenames)
+// correspond to the environment variable names for gerritstatusupdater.
+// Therefore, this filename must only be change in combination with also
+// updating the environment in which gerritstatusupdater is running for this
+// repository.
+//
+// This name is also used by the CI badge in the top-level README.
+//
+// This name is also used in the evict_caches lookups.
+//
+// i.e. don't change the names of workflows!
+//
+// In addition to separately declaring the workflows themselves, we define the
+// shape of #workflows here as a cross-check that we don't accidentally change
+// the name of workflows without reading this comment.
+//
+// We explicitly use close() here instead of a definition in order that we can
+// cue export the github package as a test.
+workflows: close({
+	[string]: json.#Workflow
+
+	trybot:             _
+	trybot_dispatch:    _
+	release:            _
+	tip_triggers:       _
+	push_tip_to_trybot: _
+	evict_caches:       _
+})
 
 // _#protectedBranchPatterns is a list of glob patterns to match the protected
 // git branches which are continuously used during development on Gerrit.

--- a/internal/ci/goreleaser/goreleaser_tool.cue
+++ b/internal/ci/goreleaser/goreleaser_tool.cue
@@ -58,9 +58,9 @@ command: release: {
 		"goreleaser", "release", "-f", "-", "--rm-dist",
 
 		// Only run the full release when running on GitHub actions for a release tag.
-		// Keep in sync with core.#releaseTagPattern, which is a globbing pattern
+		// Keep in sync with core.releaseTagPattern, which is a globbing pattern
 		// rather than a regular expression.
-		if _githubRef !~ "refs/tags/\(core.#releaseTagPrefix).*" {
+		if _githubRef !~ "refs/tags/\(core.releaseTagPrefix).*" {
 			"--snapshot"
 		},
 	]

--- a/internal/ci/vendor/vendor_tool.cue
+++ b/internal/ci/vendor/vendor_tool.cue
@@ -26,7 +26,7 @@ import (
 // project which "vendors" the various workflow-related
 // packages can specify "cue" as the value so that unity
 // tests can specify the cmd/cue binary to use.
-_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.2" @tag(cue_cmd)
+_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.5" @tag(cue_cmd)
 
 // For the commands below, note we use simple yet hacky path resolution, rather
 // than anything that might derive the module root using go list or similar, in


### PR DESCRIPTION
- internal/ci: update base early git checks from alpha.cuelang.org
- internal/ci: bump default of cue version to v0.5.0-beta.5
- internal/ci: remove the cachePost steps
- internal/ci: refactor the way we declare workflows
- internal/ci: improve core package docs
- internal/ci: move core package away from definitions
- internal/ci: move core.#codeReview to base
- internal/ci: move core._#URLPath to base
