### PR TITLE
trybot/551413/a282eab5155a59acf3dc4b6985fcb6d2dd6c9d80/551413/2

### DIFF
--- a/cmd/cue/cmd/get_go.go
+++ b/cmd/cue/cmd/get_go.go
@@ -1005,10 +1005,20 @@ func (e *extractor) makeField(name string, kind fieldKind, expr types.Type, doc 
 		cueast.SetRelPos(doc, cuetoken.NewSection)
 	}
 
-	if kind == optional {
-		f.Token = cuetoken.COLON
-		f.Optional = cuetoken.Blank.Pos()
+	var tok cuetoken.Token
+	switch kind {
+	case definition:
+		// neither optional nor required.
+	case regular:
+		// TODO(required): use idiomatic CUE (token.NOT) if CUE version is
+		// higher than a certain number? We may not be able to determine this
+		// accurately enough.
+	case optional:
+		tok = cuetoken.OPTION
 	}
+
+	internal.SetConstraint(f, tok)
+
 	b, _ := format.Node(typ)
 	return f, string(b)
 }

--- a/cmd/cue/cmd/testdata/script/injecterr.txtar
+++ b/cmd/cue/cmd/testdata/script/injecterr.txtar
@@ -26,9 +26,9 @@ cmp stderr expect-stderr
 }
 
 -- expect-stderr --
-@tag not allowed within optional fields:
+@tag not allowed within field constraint:
     ./test.cue:5:18
-@tag not allowed within optional fields:
+@tag not allowed within field constraint:
     ./test.cue:6:33
 @tag not allowed within lists:
     ./test.cue:11:30

--- a/cue/ast/ast.go
+++ b/cue/ast/ast.go
@@ -312,8 +312,9 @@ func (a *Attribute) Split() (key, body string) {
 
 // A Field represents a field declaration in a struct.
 type Field struct {
-	Label    Label // must have at least one element.
-	Optional token.Pos
+	Label      Label       // must have at least one element.
+	Optional   token.Pos   // Deprecated
+	Constraint token.Token // token.ILLEGAL, token.OPTION, or token.NOT
 
 	// No TokenPos: Value must be an StructLit with one field.
 	TokenPos token.Pos

--- a/cue/context.go
+++ b/cue/context.go
@@ -129,7 +129,7 @@ func (c *Context) BuildInstance(i *build.Instance, options ...BuildOption) Value
 func (c *Context) makeError(err errors.Error) Value {
 	b := &adt.Bottom{Err: err}
 	node := &adt.Vertex{BaseValue: b}
-	node.UpdateStatus(adt.Finalized)
+	node.ForceDone()
 	node.AddConjunct(adt.MakeRootConjunct(nil, b))
 	return c.make(node)
 }

--- a/cue/format/node.go
+++ b/cue/format/node.go
@@ -276,7 +276,8 @@ func (f *formatter) decl(decl ast.Decl) {
 
 	switch n := decl.(type) {
 	case *ast.Field:
-		f.label(n.Label, n.Optional != token.NoPos)
+		constraint, _ := internal.ConstraintToken(n)
+		f.label(n.Label, constraint)
 
 		regular := isRegularField(n.Token)
 		if regular {
@@ -437,7 +438,7 @@ func (f *formatter) nextNeedsFormfeed(n ast.Expr) bool {
 
 func (f *formatter) importSpec(x *ast.ImportSpec) {
 	if x.Name != nil {
-		f.label(x.Name, false)
+		f.label(x.Name, token.ILLEGAL)
 		f.print(blank)
 	} else {
 		f.current.pos++
@@ -458,7 +459,7 @@ func isValidIdent(ident string) bool {
 	return false
 }
 
-func (f *formatter) label(l ast.Label, optional bool) {
+func (f *formatter) label(l ast.Label, constraint token.Token) {
 	f.before(l)
 	defer f.after(l)
 	switch n := l.(type) {
@@ -497,8 +498,8 @@ func (f *formatter) label(l ast.Label, optional bool) {
 	default:
 		panic(fmt.Sprintf("unknown label type %T", n))
 	}
-	if optional {
-		f.print(token.OPTION)
+	if constraint != token.ILLEGAL {
+		f.print(constraint)
 	}
 }
 
@@ -536,7 +537,7 @@ func (f *formatter) exprRaw(expr ast.Expr, prec1, depth int) {
 
 	case *ast.Alias:
 		// Aliases in expression positions are printed in short form.
-		f.label(x.Ident, false)
+		f.label(x.Ident, token.ILLEGAL)
 		f.print(x.Equal, token.BIND)
 		f.expr(x.Expr)
 
@@ -681,13 +682,13 @@ func (f *formatter) clause(clause ast.Clause) {
 		f.print(n.For, "for", blank)
 		f.print(indent)
 		if n.Key != nil {
-			f.label(n.Key, false)
+			f.label(n.Key, token.ILLEGAL)
 			f.print(n.Colon, token.COMMA, blank)
 		} else {
 			f.current.pos++
 			f.visitComments(f.current.pos)
 		}
-		f.label(n.Value, false)
+		f.label(n.Value, token.ILLEGAL)
 		f.print(blank, n.In, "in", blank)
 		f.expr(n.Source)
 		f.markUnindentLine()

--- a/cue/format/testdata/expressions.golden
+++ b/cue/format/testdata/expressions.golden
@@ -24,6 +24,8 @@ package expressions
 		b:
 			c: 2
 
+	req!: int
+
 	a: bbbb: c: 3
 	a: b: 3
 	a: bb: cc: 3

--- a/cue/format/testdata/expressions.input
+++ b/cue/format/testdata/expressions.input
@@ -24,6 +24,8 @@ package expressions
     b:
     c: 2
 
+    req!: int
+
     a: bbbb: c: 3
     a: b: 3
     a: bb: cc: 3

--- a/cue/format/testdata/simplify.golden
+++ b/cue/format/testdata/simplify.golden
@@ -30,7 +30,9 @@ quux: 5
 // Issue #294
 "\("x")": "x"
 
-(x): "foo"
+(x):  "foo"
+(x)?: "foo"
+(x)!: "foo"
 
 a: {
 	foo: 2

--- a/cue/format/testdata/simplify.input
+++ b/cue/format/testdata/simplify.input
@@ -33,6 +33,8 @@ a:
 "\("x")": "x"
 
 (x): "foo"
+(x)?: "foo"
+(x)!: "foo"
 
 a: {
     [string]: _

--- a/cue/load/tags.go
+++ b/cue/load/tags.go
@@ -228,8 +228,9 @@ func findTags(b *build.Instance) (tags []*tag, errs errors.Error) {
 			case *ast.Field:
 				// TODO: allow optional fields?
 				_, _, err := ast.LabelName(x.Label)
-				if err != nil || x.Optional != token.NoPos {
-					findInvalidTags(n, "@tag not allowed within optional fields")
+				_, ok := internal.ConstraintToken(x)
+				if err != nil || ok {
+					findInvalidTags(n, "@tag not allowed within field constraint")
 					return false
 				}
 

--- a/cue/parser/parser.go
+++ b/cue/parser/parser.go
@@ -867,8 +867,10 @@ func (p *parser) parseField() (decl ast.Decl) {
 		return e
 	}
 
-	if p.tok == token.OPTION {
+	switch p.tok {
+	case token.OPTION, token.NOT:
 		m.Optional = p.pos
+		m.Constraint = p.tok
 		p.next()
 	}
 
@@ -916,7 +918,7 @@ func (p *parser) parseField() (decl ast.Decl) {
 		}
 
 		label, expr, _, ok := p.parseLabel(true)
-		if !ok || (p.tok != token.COLON && p.tok != token.OPTION) {
+		if !ok || (p.tok != token.COLON && p.tok != token.OPTION && p.tok != token.NOT) {
 			if expr == nil {
 				expr = p.parseRHS()
 			}
@@ -927,8 +929,10 @@ func (p *parser) parseField() (decl ast.Decl) {
 		m.Value = &ast.StructLit{Elts: []ast.Decl{field}}
 		m = field
 
-		if p.tok == token.OPTION {
+		switch p.tok {
+		case token.OPTION, token.NOT:
 			m.Optional = p.pos
+			m.Constraint = p.tok
 			p.next()
 		}
 

--- a/cue/parser/parser_test.go
+++ b/cue/parser/parser_test.go
@@ -118,9 +118,13 @@ func TestParse(t *testing.T) {
 		 b?: "2"
 		 c?: 3
 
+		 d!: 2
+		 e: f!: 3
+
 		 "g\("en")"?: 4
+		 "h\("en")"!: 4
 		`,
-		`a: true, b?: "2", c?: 3, "g\("en")"?: 4`,
+		`a: true, b?: "2", c?: 3, d!: 2, e: {f!: 3}, "g\("en")"?: 4, "h\("en")"!: 4`,
 	}, {
 		"definition",
 		`#Def: {
@@ -371,8 +375,11 @@ func TestParse(t *testing.T) {
 			a: {
 				(a.b)
 			}
+
+			(x)?: 1
+			y: (x)!: 2
 		}`,
-		`{(x): {a: int}, x: "foo", a: {(a.b)}}`,
+		`{(x): {a: int}, x: "foo", a: {(a.b)}, (x)?: 1, y: {(x)!: 2}}`,
 	}, {
 		"foo",
 		`[

--- a/cue/path.go
+++ b/cue/path.go
@@ -48,6 +48,8 @@ const (
 
 	// OptionalConstraint represents an optional constraint (?).
 	OptionalConstraint
+	// RequiredConstraint represents a required constraint (!).
+	RequiredConstraint
 	// PatternConstraint represents a selector of fields in a struct
 	// or array that match a constraint.
 	PatternConstraint
@@ -62,7 +64,7 @@ func (t SelectorType) LabelType() SelectorType {
 
 // ConstraintType reports the constraint type of t.
 func (t SelectorType) ConstraintType() SelectorType {
-	return t & 0b0110_0000
+	return t & 0b1110_0000
 }
 
 var selectorTypeStrings = [...]string{
@@ -73,6 +75,7 @@ var selectorTypeStrings = [...]string{
 	"HiddenLabel",
 	"HiddenDefinitionLabel",
 	"OptionalConstraint",
+	"RequiredConstraint",
 	"PatternConstraint",
 }
 

--- a/cue/path_test.go
+++ b/cue/path_test.go
@@ -300,7 +300,7 @@ func TestSelectorTypeString(t *testing.T) {
 	if got, want := (StringLabel | OptionalConstraint).String(), "StringLabel|OptionalConstraint"; got != want {
 		t.Errorf("unexpected SelectorType.String result; got %q want %q", got, want)
 	}
-	if got, want := SelectorType(255).String(), "StringLabel|IndexLabel|DefinitionLabel|HiddenLabel|HiddenDefinitionLabel|OptionalConstraint|PatternConstraint"; got != want {
+	if got, want := SelectorType(255).String(), "StringLabel|IndexLabel|DefinitionLabel|HiddenLabel|HiddenDefinitionLabel|OptionalConstraint|RequiredConstraint|PatternConstraint"; got != want {
 		t.Errorf("unexpected SelectorType.String result; got %q want %q", got, want)
 	}
 }

--- a/cue/testdata/benchmarks/issue1684.txtar
+++ b/cue/testdata/benchmarks/issue1684.txtar
@@ -40,7 +40,7 @@ Allocs: 49
 Retain: 0
 
 Unifications: 740771
-Conjuncts:    3143640
+Conjuncts:    2327328
 Disjuncts:    995025
 -- out/eval --
 (struct){

--- a/cue/testdata/comprehensions/pushdown.txtar
+++ b/cue/testdata/comprehensions/pushdown.txtar
@@ -742,15 +742,15 @@ unifyDynamicReflectSuccess: {
 }
 
 -- out/eval/stats --
-Leaks:  17
+Leaks:  16
 Freed:  392
-Reused: 386
+Reused: 385
 Allocs: 23
-Retain: 136
+Retain: 135
 
-Unifications: 395
-Conjuncts:    646
-Disjuncts:    485
+Unifications: 394
+Conjuncts:    644
+Disjuncts:    484
 -- out/eval --
 Errors:
 embed.fail1.p: field not allowed:
@@ -1350,7 +1350,7 @@ Result:
       y: (int){ 1 }
     }
     a: (struct){
-      let x#1multi = 〈1;v〉
+      let x#1 = (int){ 1 }
     }
   }
   nestedWithEmbeddingOK: (struct){

--- a/cue/testdata/cycle/compbottom2.txtar
+++ b/cue/testdata/cycle/compbottom2.txtar
@@ -270,7 +270,7 @@ Allocs: 10
 Retain: 76
 
 Unifications: 151
-Conjuncts:    166
+Conjuncts:    164
 Disjuncts:    205
 -- out/eval --
 (struct){
@@ -481,16 +481,16 @@ Disjuncts:    205
     }
     defCloseSuccess: (struct){
       #Example: (#struct){
+        ret?: (_){ _ }
         raises?: (#struct){
           runtime?: (string){ string }
         }
-        ret?: (_){ _ }
       }
       expr: (#struct){
+        ret: (int){ 2 }
         raises?: (#struct){
           runtime?: (string){ string }
         }
-        ret: (int){ 2 }
       }
     }
   }

--- a/cue/testdata/cycle/issue990.txtar
+++ b/cue/testdata/cycle/issue990.txtar
@@ -173,15 +173,15 @@ out: #sub & {#p: _test.s1}
   })
 }
 -- out/eval/stats --
-Leaks:  6
-Freed:  3232
-Reused: 3209
-Allocs: 29
-Retain: 43
+Leaks:  0
+Freed:  1907
+Reused: 1881
+Allocs: 26
+Retain: 24
 
-Unifications: 2588
-Conjuncts:    12056
-Disjuncts:    3275
+Unifications: 1541
+Conjuncts:    6931
+Disjuncts:    1931
 -- out/eval --
 (struct){
   #AC: (#struct){
@@ -344,9 +344,88 @@ Disjuncts:    3275
     }
   }
   out: (#struct){
-    let subs#1multi = (〈3;#sub〉 & {
-      #p: 〈2;rd〉.a
-    })
+    let subs#1 = (#struct){
+      let subs#1 = (#struct){
+        dict: (#struct){
+          r1: (#struct){
+            a: (#struct){
+              k: (string){ "simple" }
+              d: (#struct){
+                n: (string){ "c1" }
+              }
+            }
+          }
+        }
+        #p: (#struct){
+          k: (string){ "complex" }
+          d: (#struct){
+            n: (string){ "s3" }
+            r: (#struct){
+              r1: (#struct){
+                a: (#struct){
+                  k: (string){ "simple" }
+                  d: (#struct){
+                    n: (string){ "c1" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      dict: (#struct){
+        r1: (#struct){
+          a: (#struct){
+            k: (string){ "simple" }
+            d: (#struct){
+              n: (string){ "c1" }
+            }
+          }
+        }
+        r2_r1: (#struct){
+          a: (#struct){
+            k: (string){ "simple" }
+            d: (#struct){
+              n: (string){ "c1" }
+            }
+          }
+        }
+      }
+      #p: (#struct){
+        k: (string){ "complex" }
+        d: (#struct){
+          n: (string){ "s2" }
+          r: (#struct){
+            r1: (#struct){
+              a: (#struct){
+                k: (string){ "simple" }
+                d: (#struct){
+                  n: (string){ "c1" }
+                }
+              }
+            }
+            r2: (#struct){
+              a: (#struct){
+                k: (string){ "complex" }
+                d: (#struct){
+                  n: (string){ "s3" }
+                  r: (#struct){
+                    r1: (#struct){
+                      a: (#struct){
+                        k: (string){ "simple" }
+                        d: (#struct){
+                          n: (string){ "c1" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     dict: (#struct){
       r1: (#struct){
         a: (#struct){

--- a/cue/testdata/cycle/issue990.txtar
+++ b/cue/testdata/cycle/issue990.txtar
@@ -174,14 +174,14 @@ out: #sub & {#p: _test.s1}
 }
 -- out/eval/stats --
 Leaks:  6
-Freed:  3932
-Reused: 3909
+Freed:  3232
+Reused: 3209
 Allocs: 29
 Retain: 43
 
-Unifications: 3116
-Conjuncts:    15808
-Disjuncts:    3975
+Unifications: 2588
+Conjuncts:    12056
+Disjuncts:    3275
 -- out/eval --
 (struct){
   #AC: (#struct){

--- a/cue/testdata/disjunctions/incomplete.txtar
+++ b/cue/testdata/disjunctions/incomplete.txtar
@@ -57,7 +57,7 @@ Allocs: 6
 Retain: 0
 
 Unifications: 40
-Conjuncts:    101
+Conjuncts:    99
 Disjuncts:    70
 -- out/eval --
 (struct){

--- a/cue/testdata/eval/dynamic_field.txtar
+++ b/cue/testdata/eval/dynamic_field.txtar
@@ -63,16 +63,23 @@ noCycleError: {
 	foo: baz: {}
 }
 
+-- constraints.cue --
+constraints: {
+	t1: "foo"
+	t2: "bar"
+	(t1)?: (t2)!: 3
+}
+
 -- out/eval/stats --
 Leaks:  2
-Freed:  54
-Reused: 47
+Freed:  59
+Reused: 52
 Allocs: 9
-Retain: 9
+Retain: 11
 
-Unifications: 56
-Conjuncts:    73
-Disjuncts:    61
+Unifications: 61
+Conjuncts:    79
+Disjuncts:    66
 -- out/eval --
 Errors:
 invalid interpolation: conflicting values 2 and 1:
@@ -83,6 +90,13 @@ invalid interpolation: conflicting values 2 and 1:
 Result:
 (_|_){
   // [eval]
+  constraints: (struct){
+    t1: (string){ "foo" }
+    t2: (string){ "bar" }
+    foo?: (struct){
+      bar!: (int){ 3 }
+    }
+  }
   a: (string){ "foo" }
   e: (int){ 2 }
   b: (string){ "bar" }
@@ -178,6 +192,16 @@ Result:
   }
 }
 -- out/compile --
+--- constraints.cue
+{
+  constraints: {
+    t1: "foo"
+    t2: "bar"
+    〈0;t1〉?: {
+      〈1;t2〉!: 3
+    }
+  }
+}
 --- in.cue
 {
   a: "foo"

--- a/cue/testdata/eval/issue2235.txtar
+++ b/cue/testdata/eval/issue2235.txtar
@@ -100,15 +100,15 @@ for clusterName, cluster in clusters {
 
 clusters: foo: {}
 -- out/eval/stats --
-Leaks:  3
-Freed:  101
-Reused: 76
-Allocs: 28
-Retain: 128
+Leaks:  1
+Freed:  99
+Reused: 74
+Allocs: 26
+Retain: 120
 
-Unifications: 104
-Conjuncts:    273
-Disjuncts:    200
+Unifications: 100
+Conjuncts:    262
+Disjuncts:    190
 -- out/eval --
 (struct){
   shorewallParams: (#struct){
@@ -285,7 +285,19 @@ Disjuncts:    200
       }
     }
   }
-  let svc#1multi = 〈1;controller〉.objects.namespaced.ingress.Service["\(〈1;class〉)-nginx-ingress-controller"]
+  let svc#1 = (struct){
+    spec: (struct){
+      externalIPs: (#list){
+        0: (string){ "127.0.0.1" }
+      }
+    }
+    metadata: (struct){
+      labels: (struct){
+        "ingress-class": (string){ "admin" }
+        stack: (string){ "ingress" }
+      }
+    }
+  }
 }
 -- out/compile --
 --- issue2235.cue

--- a/cue/testdata/eval/let.txtar
+++ b/cue/testdata/eval/let.txtar
@@ -159,15 +159,15 @@ keepDescending: t2: {
 }
 
 -- out/eval/stats --
-Leaks:  53
-Freed:  159
-Reused: 150
-Allocs: 62
-Retain: 236
+Leaks:  45
+Freed:  161
+Reused: 152
+Allocs: 54
+Retain: 248
 
-Unifications: 198
+Unifications: 192
 Conjuncts:    384
-Disjuncts:    249
+Disjuncts:    247
 -- out/eval --
 Errors:
 indirectReference.y: conflicting values 2 and 1:
@@ -248,7 +248,14 @@ Result:
     }
   }
   referencesForDirectly: (struct){
-    let Y#1Amulti = (〈1;v〉 * 4)
+    let Y#1A = (_|_){
+      // [eval] referencesForDirectly.Y: conflicting values 12 and 4:
+      //     ./incomprehension.cue:15:2
+      //     ./incomprehension.cue:16:11
+      // referencesForDirectly.Y: conflicting values 8 and 4:
+      //     ./incomprehension.cue:15:2
+      //     ./incomprehension.cue:16:11
+    }
     l: (#list){
       0: (int){ 1 }
       1: (int){ 2 }
@@ -259,7 +266,16 @@ Result:
     "2": (int){ 12 }
   }
   referencesForViaLet: (struct){
-    let Y#1Bmulti = 〈1;X〉
+    let Y#1B = (_|_){
+      // [eval] referencesForViaLet.Y: conflicting values 12 and 4:
+      //     ./incomprehension.cue:23:2
+      //     ./incomprehension.cue:23:24
+      //     ./incomprehension.cue:24:11
+      // referencesForViaLet.Y: conflicting values 8 and 4:
+      //     ./incomprehension.cue:23:2
+      //     ./incomprehension.cue:23:24
+      //     ./incomprehension.cue:24:11
+    }
     l: (#list){
       0: (int){ 1 }
       1: (int){ 2 }
@@ -350,14 +366,10 @@ Result:
     }
   }
   nestedFor: (struct){
-    let X#1Emulti = {
-      for _, x in [
-        1,
-        2,
-      ] {
-        let X#1Fmulti = 〈1;x〉
-        "\(〈0;let X#1F〉)": 〈0;let X#1F〉
-      }
+    let X#1E = (struct){
+      let X#1Fmulti = 〈1;x〉
+      "1": (int){ 1 }
+      "2": (int){ 2 }
     }
     "0": (struct){
       let X#1Fmulti = 〈1;x〉
@@ -400,7 +412,13 @@ Result:
     }
   }
   letWithDynamicInComprehension: (struct){
-    let T#23multi = 〈1;v〉
+    let T#23 = (_|_){
+      // [eval] letWithDynamicInComprehension.T: conflicting values "e" and "d":
+      //     ./issue2166.cue:3:6
+      //     ./issue2166.cue:4:6
+      //     ./issue2166.cue:7:2
+      //     ./issue2166.cue:8:11
+    }
     _i: (struct){
       a: (string){ "d" }
       b: (string){ "e" }
@@ -421,12 +439,12 @@ Result:
     }
   }
   disabled_parent_test: (struct){
-    let parent_config#24multi = (*〈3;_parent_configs〉[〈1;v〉.parent]|false)
+    let parent_config#24 = (bool){ false }
     CHILD1: (struct){
       parent_config: (bool){ false }
     }
     CHILD2: (struct){
-      parent_config: (bool){ |(*(bool){ true }, (bool){ false }) }
+      parent_config: (bool){ false }
     }
   }
 }

--- a/cue/testdata/eval/required.txtar
+++ b/cue/testdata/eval/required.txtar
@@ -1,0 +1,134 @@
+-- in.cue --
+self: t1: {
+	a?: int
+}
+
+self: t2: {
+	a!: int
+	a!: int
+}
+
+unify: t1: p1: {
+	a!: int
+	a: int
+}
+
+unify: t1: p2: {
+	a: int
+	a!: int
+}
+
+unify: t2: p1: {
+	a!: int
+	a?: int
+}
+
+unify: t2: p2: {
+	a?: int
+	a!: int
+}
+#Def: t1: {
+	a!: int
+}
+-- out/compile --
+--- in.cue
+{
+  self: {
+    t1: {
+      a?: int
+    }
+  }
+  self: {
+    t2: {
+      a!: int
+      a!: int
+    }
+  }
+  unify: {
+    t1: {
+      p1: {
+        a!: int
+        a: int
+      }
+    }
+  }
+  unify: {
+    t1: {
+      p2: {
+        a: int
+        a!: int
+      }
+    }
+  }
+  unify: {
+    t2: {
+      p1: {
+        a!: int
+        a?: int
+      }
+    }
+  }
+  unify: {
+    t2: {
+      p2: {
+        a?: int
+        a!: int
+      }
+    }
+  }
+  #Def: {
+    t1: {
+      a!: int
+    }
+  }
+}
+-- out/eval/stats --
+Leaks:  0
+Freed:  20
+Reused: 15
+Allocs: 5
+Retain: 0
+
+Unifications: 20
+Conjuncts:    31
+Disjuncts:    20
+-- out/eval --
+Errors:
+self.t2.a: field is required but not present
+unify.t2.p1.a: field is required but not present
+unify.t2.p2.a: field is required but not present
+
+Result:
+(struct){
+  self: (struct){
+    t1: (struct){
+      a?: (int){ int }
+    }
+    t2: (struct){
+      a!: (int){ int }
+    }
+  }
+  unify: (struct){
+    t1: (struct){
+      p1: (struct){
+        a: (int){ int }
+      }
+      p2: (struct){
+        a: (int){ int }
+      }
+    }
+    t2: (struct){
+      p1: (struct){
+        a!: (int){ int }
+      }
+      p2: (struct){
+        a!: (int){ int }
+      }
+    }
+  }
+  #Def: (#struct){
+    t1: (#struct){
+      a!: (int){ int }
+    }
+  }
+}

--- a/cue/testdata/export/030.txtar
+++ b/cue/testdata/export/030.txtar
@@ -55,14 +55,14 @@ eval: true
 }
 -- out/eval/stats --
 Leaks:  0
-Freed:  82
-Reused: 70
-Allocs: 12
+Freed:  70
+Reused: 59
+Allocs: 11
 Retain: 1
 
 Unifications: 28
-Conjuncts:    165
-Disjuncts:    83
+Conjuncts:    131
+Disjuncts:    71
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/resolve/009_optional_field_unification.txtar
+++ b/cue/testdata/resolve/009_optional_field_unification.txtar
@@ -88,5 +88,5 @@ Disjuncts:    11
     foo?: (string){ "bar" }
   }
   g1: (int){ 1 }
-  g2: (int){ 2 }
+  g2?: (int){ 2 }
 }

--- a/cue/types.go
+++ b/cue/types.go
@@ -2368,8 +2368,8 @@ func (v Value) Expr() (Op, []Value) {
 					b.AddConjunct(adt.MakeRootConjunct(env, disjunct.Val))
 
 					ctx := eval.NewContext(v.idx, nil)
-					ctx.Unify(&a, adt.Finalized)
-					ctx.Unify(&b, adt.Finalized)
+					a.Finalize(ctx)
+					b.Finalize(ctx)
 					if allowed(ctx, v.v, &b) != nil {
 						// Everything subsumed bottom
 						continue outerExpr

--- a/cue/types.go
+++ b/cue/types.go
@@ -601,7 +601,7 @@ func newErrValue(v Value, b *adt.Bottom) Value {
 		node.Label = v.v.Label
 		node.Parent = v.v.Parent
 	}
-	node.UpdateStatus(adt.Finalized)
+	node.ForceDone()
 	node.AddConjunct(adt.MakeRootConjunct(nil, b))
 	return makeChildValue(v.parent(), node)
 }
@@ -612,7 +612,7 @@ func newVertexRoot(idx *runtime.Runtime, ctx *adt.OpContext, x *adt.Vertex) Valu
 		// with an error value.
 		x.Finalize(ctx)
 	} else {
-		x.UpdateStatus(adt.Finalized)
+		x.ForceDone()
 	}
 	return makeValue(idx, x, nil)
 }
@@ -699,7 +699,7 @@ func remakeValue(base Value, env *adt.Environment, v adt.Expr) Value {
 
 func remakeFinal(base Value, env *adt.Environment, v adt.Value) Value {
 	n := &adt.Vertex{Parent: base.v.Parent, Label: base.v.Label, BaseValue: v}
-	n.UpdateStatus(adt.Finalized)
+	n.ForceDone()
 	return makeChildValue(base.parent(), n)
 }
 
@@ -1864,7 +1864,7 @@ func (v Value) Unify(w Value) Value {
 	n.Label = v.v.Label
 	n.Closed = v.v.Closed || w.v.Closed
 
-	if err := n.Err(ctx, adt.Finalized); err != nil {
+	if err := n.Err(ctx); err != nil {
 		return makeValue(v.idx, n, v.parent_)
 	}
 	if err := allowed(ctx, v.v, n); err != nil {
@@ -1900,7 +1900,7 @@ func (v Value) UnifyAccept(w Value, accept Value) Value {
 	n.Parent = v.v.Parent
 	n.Label = v.v.Label
 
-	if err := n.Err(ctx, adt.Finalized); err != nil {
+	if err := n.Err(ctx); err != nil {
 		return makeValue(v.idx, n, v.parent_)
 	}
 	if err := allowed(ctx, accept.v, n); err != nil {

--- a/cue/types.go
+++ b/cue/types.go
@@ -1732,6 +1732,8 @@ func (v Value) FillPath(p Path, x interface{}) Value {
 			switch sel.ConstraintType() {
 			case OptionalConstraint:
 				f.ArcType = adt.ArcOptional
+			case RequiredConstraint:
+				f.ArcType = adt.ArcRequired
 			}
 
 			expr = &adt.StructLit{Decls: []adt.Decl{f}}

--- a/cue/types.go
+++ b/cue/types.go
@@ -687,7 +687,7 @@ func linkParent(p *parent, node, arc *adt.Vertex) *parent {
 func remakeValue(base Value, env *adt.Environment, v adt.Expr) Value {
 	// TODO: right now this is necessary because disjunctions do not have
 	// populated conjuncts.
-	if v, ok := v.(*adt.Vertex); ok && v.Status() >= adt.Partial {
+	if v, ok := v.(*adt.Vertex); ok && !v.IsUnprocessed() {
 		return Value{base.idx, v, nil}
 	}
 	n := &adt.Vertex{Label: base.v.Label}

--- a/cue/types.go
+++ b/cue/types.go
@@ -1724,19 +1724,17 @@ func (v Value) FillPath(p Path, x interface{}) Value {
 			expr = list
 
 		default:
-			var d adt.Decl
-			if sel.ConstraintType() == OptionalConstraint {
-				d = &adt.OptionalField{
-					Label: sel.sel.feature(v.idx),
-					Value: expr,
-				}
-			} else {
-				d = &adt.Field{
-					Label: sel.sel.feature(v.idx),
-					Value: expr,
-				}
+			f := &adt.Field{
+				Label:   sel.sel.feature(v.idx),
+				Value:   expr,
+				ArcType: adt.ArcMember,
 			}
-			expr = &adt.StructLit{Decls: []adt.Decl{d}}
+			switch sel.ConstraintType() {
+			case OptionalConstraint:
+				f.ArcType = adt.ArcOptional
+			}
+
+			expr = &adt.StructLit{Decls: []adt.Decl{f}}
 		}
 	}
 	n := &adt.Vertex{}

--- a/internal/astinternal/debugstr.go
+++ b/internal/astinternal/debugstr.go
@@ -21,6 +21,7 @@ import (
 
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal"
 )
 
 func DebugStr(x interface{}) (out string) {
@@ -126,8 +127,8 @@ func DebugStr(x interface{}) (out string) {
 
 	case *ast.Field:
 		out := DebugStr(v.Label)
-		if v.Optional != token.NoPos {
-			out += "?"
+		if t, ok := internal.ConstraintToken(v); ok {
+			out += t.String()
 		}
 		if v.Value != nil {
 			switch v.Token {

--- a/internal/core/adt/adt.go
+++ b/internal/core/adt/adt.go
@@ -234,8 +234,6 @@ func (*CallExpr) expr()      {}
 
 func (*Field) declNode()                {}
 func (x *Field) expr() Expr             { return x.Value }
-func (*OptionalField) declNode()        {}
-func (x *OptionalField) expr() Expr     { return x.Value }
 func (*LetField) declNode()             {}
 func (x *LetField) expr() Expr          { return x.Value }
 func (*BulkOptionalField) declNode()    {}
@@ -371,7 +369,6 @@ func (*BinaryExpr) node()        {}
 func (*CallExpr) node()          {}
 func (*DisjunctionExpr) node()   {}
 func (*Field) node()             {}
-func (*OptionalField) node()     {}
 func (*LetField) node()          {}
 func (*BulkOptionalField) node() {}
 func (*DynamicField) node()      {}

--- a/internal/core/adt/adt.go
+++ b/internal/core/adt/adt.go
@@ -39,7 +39,7 @@ func Resolve(ctx *OpContext, c Conjunct) *Vertex {
 		v = x
 
 	case Resolver:
-		r, err := ctx.resolveState(c, x, Finalized)
+		r, err := ctx.resolveState(c, x, finalized)
 		if err != nil {
 			v = err
 			break
@@ -108,14 +108,14 @@ type Evaluator interface {
 
 	// evaluate evaluates the underlying expression. If the expression
 	// is incomplete, it may record the error in ctx and return nil.
-	evaluate(ctx *OpContext, state VertexStatus) Value
+	evaluate(ctx *OpContext, state vertexStatus) Value
 }
 
 // A Resolver represents a reference somewhere else within a tree that resolves
 // a value.
 type Resolver interface {
 	Node
-	resolve(ctx *OpContext, state VertexStatus) *Vertex
+	resolve(ctx *OpContext, state vertexStatus) *Vertex
 }
 
 type YieldFunc func(env *Environment)

--- a/internal/core/adt/binop.go
+++ b/internal/core/adt/binop.go
@@ -75,8 +75,8 @@ func BinOp(c *OpContext, op Op, left, right Value) Value {
 				return c.newBool(false)
 			}
 			for i, e := range x {
-				a, _ := c.Concrete(nil, e, op)
-				b, _ := c.Concrete(nil, y[i], op)
+				a, _ := c.concrete(nil, e, op)
+				b, _ := c.concrete(nil, y[i], op)
 				if !test(c, EqualOp, a, b) {
 					return c.newBool(false)
 				}
@@ -113,8 +113,8 @@ func BinOp(c *OpContext, op Op, left, right Value) Value {
 				return c.newBool(false)
 			}
 			for i, e := range x {
-				a, _ := c.Concrete(nil, e, op)
-				b, _ := c.Concrete(nil, y[i], op)
+				a, _ := c.concrete(nil, e, op)
+				b, _ := c.concrete(nil, y[i], op)
 				if !test(c, EqualOp, a, b) {
 					return c.newBool(true)
 				}

--- a/internal/core/adt/binop.go
+++ b/internal/core/adt/binop.go
@@ -207,7 +207,7 @@ func BinOp(c *OpContext, op Op, left, right Value) Value {
 
 			n := &Vertex{}
 			n.AddConjunct(MakeConjunct(c.Env(0), list, c.ci))
-			c.Unify(n, Conjuncts)
+			n.CompleteArcs(c)
 
 			return n
 		}
@@ -269,7 +269,7 @@ func BinOp(c *OpContext, op Op, left, right Value) Value {
 
 			n := &Vertex{}
 			n.AddConjunct(MakeConjunct(c.Env(0), list, c.ci))
-			c.Unify(n, Conjuncts)
+			n.CompleteArcs(c)
 
 			return n
 		}

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -256,7 +256,7 @@ func (v *Vertex) IsDefined(c *OpContext) bool {
 	if v.isDefined() {
 		return true
 	}
-	c.Unify(v, Finalized)
+	v.Finalize(c)
 	return v.isDefined()
 }
 
@@ -566,7 +566,7 @@ func (v *Vertex) IsErr() bool {
 }
 
 func (v *Vertex) Err(c *OpContext, state VertexStatus) *Bottom {
-	c.Unify(v, state)
+	c.unify(v, state)
 	if b, ok := v.BaseValue.(*Bottom); ok {
 		return b
 	}
@@ -580,8 +580,13 @@ func (v *Vertex) Finalize(c *OpContext) {
 	// case the caller did not handle existing errors in the context.
 	err := c.errs
 	c.errs = nil
-	c.Unify(v, Finalized)
+	c.unify(v, Finalized)
 	c.errs = err
+}
+
+// CompleteArcs ensures the set of arcs has been computed.
+func (v *Vertex) CompleteArcs(c *OpContext) {
+	c.unify(v, Conjuncts)
 }
 
 func (v *Vertex) AddErr(ctx *OpContext, b *Bottom) {

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -281,6 +281,16 @@ const (
 	ArcVoid
 )
 
+// Suffix reports the field suffix for the given ArcType if it is a
+// constraint or the empty string otherwise.
+func (a ArcType) Suffix() string {
+	switch a {
+	case ArcOptional:
+		return "?"
+	}
+	return ""
+}
+
 func (v *Vertex) Clone() *Vertex {
 	c := *v
 	c.state = nil
@@ -814,8 +824,12 @@ func (v *Vertex) AddConjunct(c Conjunct) *Bottom {
 }
 
 func (v *Vertex) hasConjunct(c Conjunct) (added bool) {
-	switch c.x.(type) {
-	case *OptionalField, *BulkOptionalField, *Ellipsis:
+	switch f := c.x.(type) {
+	case *BulkOptionalField, *Ellipsis:
+	case *Field:
+		if f.ArcType == ArcMember {
+			v.ArcType = ArcMember
+		}
 	default:
 		v.ArcType = ArcMember
 	}

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -281,6 +281,29 @@ const (
 	ArcVoid
 )
 
+// ConstraintFromToken converts a given AST constraint token to the
+// corresponding ArcType.
+func ConstraintFromToken(t token.Token) ArcType {
+	switch t {
+	case token.OPTION:
+		return ArcOptional
+		// TODO
+		// case token.NOT:
+		// 	return ArcRequired
+	}
+	return ArcMember
+}
+
+// Token reports the token corresponding to the constraint represented by a,
+// or token.ILLEGAL otherwise.
+func (a ArcType) Token() (t token.Token) {
+	switch a {
+	case ArcOptional:
+		t = token.OPTION
+	}
+	return t
+}
+
 // Suffix reports the field suffix for the given ArcType if it is a
 // constraint or the empty string otherwise.
 func (a ArcType) Suffix() string {

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -409,7 +409,12 @@ func (v *Vertex) Status() VertexStatus {
 	return v.status
 }
 
-func (v *Vertex) UpdateStatus(s VertexStatus) {
+// ForceDone prevents v from being evaluated.
+func (v *Vertex) ForceDone() {
+	v.updateStatus(Finalized)
+}
+
+func (v *Vertex) updateStatus(s VertexStatus) {
 	Assertf(v.status <= s+1, "attempt to regress status from %d to %d", v.Status(), s)
 
 	if s == Finalized && v.BaseValue == nil {
@@ -565,8 +570,8 @@ func (v *Vertex) IsErr() bool {
 	return false
 }
 
-func (v *Vertex) Err(c *OpContext, state VertexStatus) *Bottom {
-	c.unify(v, state)
+func (v *Vertex) Err(c *OpContext) *Bottom {
+	v.Finalize(c)
 	if b, ok := v.BaseValue.(*Bottom); ok {
 		return b
 	}
@@ -590,12 +595,17 @@ func (v *Vertex) CompleteArcs(c *OpContext) {
 }
 
 func (v *Vertex) AddErr(ctx *OpContext, b *Bottom) {
-	v.SetValue(ctx, Finalized, CombineErrors(nil, v.Value(), b))
+	v.SetValue(ctx, CombineErrors(nil, v.Value(), b))
 }
 
-func (v *Vertex) SetValue(ctx *OpContext, state VertexStatus, value BaseValue) *Bottom {
+// SetValue sets the value of a node.
+func (v *Vertex) SetValue(ctx *OpContext, value BaseValue) *Bottom {
+	return v.setValue(ctx, Finalized, value)
+}
+
+func (v *Vertex) setValue(ctx *OpContext, state VertexStatus, value BaseValue) *Bottom {
 	v.BaseValue = value
-	v.UpdateStatus(state)
+	v.updateStatus(state)
 	return nil
 }
 

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -245,7 +245,7 @@ func (v *Vertex) isDefined() bool {
 
 // IsConstraint reports whether the Vertex is an optional or required field.
 func (v *Vertex) IsConstraint() bool {
-	return v.ArcType == ArcOptional
+	return v.ArcType == ArcOptional || v.ArcType == ArcRequired
 }
 
 // IsDefined indicates whether this arc is defined meaning it is not a
@@ -267,7 +267,12 @@ const (
 	// (including regular, hidden, and definition fields).
 	ArcMember ArcType = iota
 
-	// ArcOptional represents fields of the form foo?.
+	// ArcRequired is like optional, but requires that a field be specified.
+	// Fields are of the form foo!.
+	ArcRequired
+
+	// ArcOptional represents fields of the form foo? and defines constraints
+	// for foo in case it is defined.
 	ArcOptional
 
 	// TODO: define a type for optional arcs. This will be needed for pulling
@@ -287,9 +292,8 @@ func ConstraintFromToken(t token.Token) ArcType {
 	switch t {
 	case token.OPTION:
 		return ArcOptional
-		// TODO
-		// case token.NOT:
-		// 	return ArcRequired
+	case token.NOT:
+		return ArcRequired
 	}
 	return ArcMember
 }
@@ -300,6 +304,8 @@ func (a ArcType) Token() (t token.Token) {
 	switch a {
 	case ArcOptional:
 		t = token.OPTION
+	case ArcRequired:
+		t = token.NOT
 	}
 	return t
 }
@@ -310,6 +316,8 @@ func (a ArcType) Suffix() string {
 	switch a {
 	case ArcOptional:
 		return "?"
+	case ArcRequired:
+		return "!"
 	}
 	return ""
 }
@@ -850,9 +858,7 @@ func (v *Vertex) hasConjunct(c Conjunct) (added bool) {
 	switch f := c.x.(type) {
 	case *BulkOptionalField, *Ellipsis:
 	case *Field:
-		if f.ArcType == ArcMember {
-			v.ArcType = ArcMember
-		}
+		v.UpdateArcType(f.ArcType)
 	default:
 		v.ArcType = ArcMember
 	}

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -859,6 +859,8 @@ func (v *Vertex) hasConjunct(c Conjunct) (added bool) {
 	case *BulkOptionalField, *Ellipsis:
 	case *Field:
 		v.UpdateArcType(f.ArcType)
+	case *DynamicField:
+		v.UpdateArcType(f.ArcType)
 	default:
 		v.ArcType = ArcMember
 	}

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -230,8 +230,8 @@ type Vertex struct {
 	Structs []*StructInfo
 }
 
-// UpdateArcType updates v.ArcType if t is more restrictive.
-func (v *Vertex) UpdateArcType(t ArcType) {
+// updateArcType updates v.ArcType if t is more restrictive.
+func (v *Vertex) updateArcType(t ArcType) {
 	if t < v.ArcType {
 		v.ArcType = t
 	}
@@ -829,7 +829,7 @@ func (v *Vertex) Elems() []*Vertex {
 func (v *Vertex) GetArc(c *OpContext, f Feature, t ArcType) (arc *Vertex, isNew bool) {
 	arc = v.Lookup(f)
 	if arc != nil {
-		arc.UpdateArcType(t)
+		arc.updateArcType(t)
 		return arc, false
 	}
 
@@ -879,9 +879,9 @@ func (v *Vertex) hasConjunct(c Conjunct) (added bool) {
 	switch f := c.x.(type) {
 	case *BulkOptionalField, *Ellipsis:
 	case *Field:
-		v.UpdateArcType(f.ArcType)
+		v.updateArcType(f.ArcType)
 	case *DynamicField:
-		v.UpdateArcType(f.ArcType)
+		v.updateArcType(f.ArcType)
 	default:
 		v.ArcType = ArcMember
 	}

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -268,7 +268,7 @@ type compState struct {
 	comp  *Comprehension
 	i     int
 	f     YieldFunc
-	state VertexStatus
+	state vertexStatus
 }
 
 // yield evaluates a Comprehension within the given Environment and and calls
@@ -277,7 +277,7 @@ func (c *OpContext) yield(
 	node *Vertex, // errors are associated with this node
 	env *Environment, // env for field for which this yield is called
 	comp *Comprehension,
-	state VertexStatus,
+	state vertexStatus,
 	f YieldFunc, // called for every result
 ) *Bottom {
 	s := &compState{
@@ -323,7 +323,7 @@ func (s *compState) yield(env *Environment) (ok bool) {
 // injectComprehension evaluates and inserts embeddings. It first evaluates all
 // embeddings before inserting the results to ensure that the order of
 // evaluation does not matter.
-func (n *nodeContext) injectComprehensions(allP *[]envYield, allowCycle bool, state VertexStatus) (progress bool) {
+func (n *nodeContext) injectComprehensions(allP *[]envYield, allowCycle bool, state vertexStatus) (progress bool) {
 	ctx := n.ctx
 
 	all := *allP

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -169,8 +169,6 @@ func (n *nodeContext) insertComprehension(
 			case *Field:
 				numFixed++
 
-				arc, _ := n.node.GetArc(n.ctx, f.Label, ArcVoid)
-
 				// Create partial comprehension
 				c := &Comprehension{
 					Syntax:  c.Syntax,
@@ -183,19 +181,15 @@ func (n *nodeContext) insertComprehension(
 					arc:    n.node,
 				}
 
-				arc.addConjunctUnchecked(MakeConjunct(env, c, ci))
+				conjunct := MakeConjunct(env, c, ci)
+				n.node.state.insertFieldUnchecked(f.Label, ArcVoid, conjunct)
 				fields = append(fields, f)
 				// TODO: adjust ci to embed?
-
-				// TODO: this also needs to be done for optional fields.
 
 			case *LetField:
 				// TODO: consider merging this case with the LetField case.
 
 				numFixed++
-
-				arc, _ := n.node.GetArc(n.ctx, f.Label, ArcVoid)
-				arc.MultiLet = f.IsMulti
 
 				// Create partial comprehension
 				c := &Comprehension{
@@ -208,7 +202,8 @@ func (n *nodeContext) insertComprehension(
 					arc:    n.node,
 				}
 
-				arc.addConjunctUnchecked(MakeConjunct(env, c, ci))
+				conjunct := MakeConjunct(env, c, ci)
+				n.node.state.insertFieldUnchecked(f.Label, ArcVoid, conjunct)
 				fields = append(fields, f)
 
 			default:

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -176,6 +176,7 @@ func (n *nodeContext) insertComprehension(
 					Syntax:  c.Syntax,
 					Clauses: c.Clauses,
 					Value:   f,
+					arcType: f.ArcType,
 
 					comp:   ec,
 					parent: c,
@@ -405,7 +406,7 @@ func (n *nodeContext) injectComprehensions(allP *[]envYield, allowCycle bool, st
 
 		v := n.node
 		for c := d.leaf; c.parent != nil; c = c.parent {
-			v.ArcType = ArcMember
+			v.UpdateArcType(c.arcType)
 			v = c.arc
 		}
 

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -406,7 +406,7 @@ func (n *nodeContext) injectComprehensions(allP *[]envYield, allowCycle bool, st
 
 		v := n.node
 		for c := d.leaf; c.parent != nil; c = c.parent {
-			v.UpdateArcType(c.arcType)
+			v.updateArcType(c.arcType)
 			v = c.arc
 		}
 

--- a/internal/core/adt/context.go
+++ b/internal/core/adt/context.go
@@ -320,7 +320,7 @@ func (c *OpContext) Env(upCount int32) *Environment {
 
 func (c *OpContext) relNode(upCount int32) *Vertex {
 	e := c.e.up(upCount)
-	c.Unify(e.Vertex, Partial)
+	c.unify(e.Vertex, Partial)
 	return e.Vertex
 }
 
@@ -779,7 +779,7 @@ func (c *OpContext) unifyNode(v Expr, state VertexStatus) (result Value) {
 		}
 
 		if v.isUndefined() || state > v.status {
-			c.Unify(v, state)
+			c.unify(v, state)
 		}
 
 		return v
@@ -859,9 +859,9 @@ func (c *OpContext) lookup(x *Vertex, pos token.Pos, l Feature, state VertexStat
 		// hasAllConjuncts, but that are finalized too early, get conjuncts
 		// processed beforehand.
 		if state > a.status {
-			c.Unify(a, state)
+			c.unify(a, state)
 		} else if a.state != nil {
-			c.Unify(a, Partial)
+			c.unify(a, Partial)
 		}
 
 		if a.IsConstraint() {
@@ -1329,6 +1329,6 @@ func (c *OpContext) NewList(values ...Value) *Vertex {
 	for _, x := range values {
 		list.Elems = append(list.Elems, x)
 	}
-	c.Unify(v, Finalized)
+	v.Finalize(c)
 	return v
 }

--- a/internal/core/adt/context.go
+++ b/internal/core/adt/context.go
@@ -520,9 +520,9 @@ func (c *OpContext) Validate(check Validator, value Value) *Bottom {
 	return err
 }
 
-// Concrete returns the concrete value of x after evaluating it.
+// concrete returns the concrete value of x after evaluating it.
 // msg is used to mention the context in which an error occurred, if any.
-func (c *OpContext) Concrete(env *Environment, x Expr, msg interface{}) (result Value, complete bool) {
+func (c *OpContext) concrete(env *Environment, x Expr, msg interface{}) (result Value, complete bool) {
 
 	w, complete := c.Evaluate(env, x)
 

--- a/internal/core/adt/cycle.go
+++ b/internal/core/adt/cycle.go
@@ -303,7 +303,7 @@ func (n *nodeContext) markCycle(arc *Vertex, env *Environment, x Resolver, ci Cl
 		// graph will always be the same address. Hence, if this is a
 		// finalized arc with a different address, it resembles a reference that
 		// is included through a different path and is not a cycle.
-		if r.Arc != arc && arc.status == Finalized {
+		if r.Arc != arc && arc.status == finalized {
 			continue
 		}
 
@@ -358,7 +358,7 @@ func (n *nodeContext) markCycle(arc *Vertex, env *Environment, x Resolver, ci Cl
 	// detected, which may be critical for performance.
 outer:
 	switch arc.status {
-	case EvaluatingArcs: // also  Evaluating?
+	case evaluatingArcs: // also  Evaluating?
 		// The reference may already be there if we had no-cyclic structure
 		// invalidating the cycle.
 		for r := arc.cyclicReferences; r != nil; r = r.Next {
@@ -373,7 +373,7 @@ outer:
 			Next: arc.cyclicReferences,
 		}
 
-	case Finalized:
+	case finalized:
 		// Insert cyclic references from found arc, if any.
 		for r := arc.cyclicReferences; r != nil; r = r.Next {
 			if r.Ref == x {
@@ -429,7 +429,7 @@ outer:
 		}
 	}
 
-	if !found && arc.status != EvaluatingArcs {
+	if !found && arc.status != evaluatingArcs {
 		// No cycle.
 		return ci, false
 	}

--- a/internal/core/adt/disjunct.go
+++ b/internal/core/adt/disjunct.go
@@ -119,7 +119,7 @@ func (n *nodeContext) addDisjunctionValue(env *Environment, x *Disjunction, clon
 }
 
 func (n *nodeContext) expandDisjuncts(
-	state VertexStatus,
+	state vertexStatus,
 	parent *nodeContext,
 	parentMode defaultMode, // default mode of this disjunct
 	recursive, last bool) {
@@ -138,7 +138,7 @@ func (n *nodeContext) expandDisjuncts(
 		n.node = node
 	}()
 
-	for n.expandOne(Partial) {
+	for n.expandOne(partial) {
 	}
 
 	// save node to snapShot in nodeContex
@@ -202,7 +202,7 @@ func (n *nodeContext) expandDisjuncts(
 	case len(n.disjunctions) > 0:
 		// Process full disjuncts to ensure that erroneous disjuncts are
 		// eliminated as early as possible.
-		state = Finalized
+		state = finalized
 
 		n.disjuncts = append(n.disjuncts, n)
 
@@ -392,7 +392,7 @@ func (n *nodeContext) expandDisjuncts(
 				// errors are not yet detected. This may lead two structs that
 				// are identical except for closedness information,
 				// for instance, to appear identical.
-				if v.result.status < Finalized || d.result.status < Finalized {
+				if v.result.status < finalized || d.result.status < finalized {
 					break
 				}
 				// Even if a node is finalized, it may still have an
@@ -481,7 +481,7 @@ func clone(v Vertex) Vertex {
 		v.Arcs = make([]*Vertex, len(a))
 		for i, arc := range a {
 			switch arc.status {
-			case Finalized:
+			case finalized:
 				v.Arcs[i] = arc
 
 			case 0:

--- a/internal/core/adt/disjunct.go
+++ b/internal/core/adt/disjunct.go
@@ -450,7 +450,7 @@ func (n *nodeContext) makeError() {
 		Code: code,
 		Err:  n.disjunctError(),
 	}
-	n.node.SetValue(n.ctx, Finalized, b)
+	n.node.SetValue(n.ctx, b)
 }
 
 func mode(hasDefault, marked bool) defaultMode {

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -1039,7 +1039,7 @@ func (n *nodeContext) clone() *nodeContext {
 	d.hasNonCycle = n.hasNonCycle
 	d.depth = n.depth
 
-	// d.arcMap = append(d.arcMap, n.arcMap...) // XXX add?
+	d.arcMap = append(d.arcMap, n.arcMap...)
 	d.cyclicConjuncts = append(d.cyclicConjuncts, n.cyclicConjuncts...)
 	d.notify = append(d.notify, n.notify...)
 	d.checks = append(d.checks, n.checks...)

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -76,7 +76,7 @@ var incompleteSentinel = &Bottom{
 func (c *OpContext) evaluate(v *Vertex, r Resolver, state VertexStatus) Value {
 	if v.isUndefined() {
 		// Use node itself to allow for cycle detection.
-		c.Unify(v, state)
+		c.unify(v, state)
 
 		if v.ArcType == ArcVoid {
 			if v.status == Evaluating {
@@ -145,10 +145,12 @@ func (c *OpContext) evaluate(v *Vertex, r Resolver, state VertexStatus) Value {
 	return v
 }
 
-// Unify fully unifies all values of a Vertex to completion and stores
-// the result in the Vertex. If unify was called on v before it returns
-// the cached results.
-func (c *OpContext) Unify(v *Vertex, state VertexStatus) {
+// unify unifies values of a Vertex to and stores the result in the Vertex. If
+// unify was called on v before it returns the cached results.
+// state can be used to indicate to which extent processing should continue.
+// state == finalized means it is evaluated to completion. See vertexStatus
+// for more details.
+func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 	// defer c.PopVertex(c.PushVertex(v))
 	if Debug {
 		c.nest++
@@ -752,7 +754,7 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 
 			wasVoid := a.ArcType == ArcVoid
 
-			ctx.Unify(a, Finalized)
+			ctx.unify(a, Finalized)
 
 			if a.ArcType == ArcVoid {
 				continue
@@ -1619,7 +1621,7 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 		// is necessary to prevent lookups in unevaluated structs.
 		// TODO(cycles): this can probably most easily be fixed with a
 		// having a more recursive implementation.
-		n.ctx.Unify(arc, Partial)
+		n.ctx.unify(arc, Partial)
 	}
 
 	// Don't add conjuncts if a node is referring to itself.

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -2079,7 +2079,7 @@ func (n *nodeContext) injectDynamic() (progress bool) {
 		if f.IsInt() {
 			n.addErr(ctx.NewPosf(pos(d.field.Key), "integer fields not supported"))
 		}
-		n.insertField(f, ArcMember, MakeConjunct(d.env, d.field, d.id))
+		n.insertField(f, d.field.ArcType, MakeConjunct(d.env, d.field, d.id))
 	}
 
 	progress = k < len(n.dynamicFields)

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -73,13 +73,13 @@ var incompleteSentinel = &Bottom{
 // error.
 //
 // TODO: return *Vertex
-func (c *OpContext) evaluate(v *Vertex, r Resolver, state VertexStatus) Value {
+func (c *OpContext) evaluate(v *Vertex, r Resolver, state vertexStatus) Value {
 	if v.isUndefined() {
 		// Use node itself to allow for cycle detection.
 		c.unify(v, state)
 
 		if v.ArcType == ArcVoid {
-			if v.status == Evaluating {
+			if v.status == evaluating {
 				for ; v.Parent != nil && v.ArcType == ArcVoid; v = v.Parent {
 				}
 				err := c.Newf("cycle with field %v", r)
@@ -117,7 +117,7 @@ func (c *OpContext) evaluate(v *Vertex, r Resolver, state VertexStatus) Value {
 
 	case nil:
 		if v.state != nil {
-			switch x := v.state.getValidators(Finalized).(type) {
+			switch x := v.state.getValidators(finalized).(type) {
 			case Value:
 				return x
 			default:
@@ -131,7 +131,7 @@ func (c *OpContext) evaluate(v *Vertex, r Resolver, state VertexStatus) Value {
 		return nil
 	}
 
-	if v.status < Finalized && v.state != nil {
+	if v.status < finalized && v.state != nil {
 		// TODO: errors are slightly better if we always add addNotify, but
 		// in this case it is less likely to cause a performance penalty.
 		// See https://cuelang.org/issue/661. It may be possible to
@@ -150,7 +150,7 @@ func (c *OpContext) evaluate(v *Vertex, r Resolver, state VertexStatus) Value {
 // state can be used to indicate to which extent processing should continue.
 // state == finalized means it is evaluated to completion. See vertexStatus
 // for more details.
-func (c *OpContext) unify(v *Vertex, state VertexStatus) {
+func (c *OpContext) unify(v *Vertex, state vertexStatus) {
 	// defer c.PopVertex(c.PushVertex(v))
 	if Debug {
 		c.nest++
@@ -172,18 +172,18 @@ func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 	}
 
 	if state <= v.Status() &&
-		state == Partial &&
+		state == partial &&
 		v.isDefined() &&
 		n != nil && n.scalar != nil {
 		return
 	}
 
 	switch v.Status() {
-	case Evaluating:
+	case evaluating:
 		n.insertConjuncts(state)
 		return
 
-	case EvaluatingArcs:
+	case evaluatingArcs:
 		Assertf(v.status > 0, "unexpected status %d", v.status)
 		return
 
@@ -200,7 +200,7 @@ func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 
 		defer c.PopArc(c.PushArc(v))
 
-		v.updateStatus(Evaluating)
+		v.updateStatus(evaluating)
 
 		if p := v.Parent; p != nil && p.state != nil && v.Label.IsString() {
 			for _, s := range p.state.node.Structs {
@@ -230,18 +230,18 @@ func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 		n.conjuncts = v.Conjuncts
 		if n.insertConjuncts(state) {
 			n.maybeSetCache()
-			v.updateStatus(Partial)
+			v.updateStatus(partial)
 			return
 		}
 
 		fallthrough
 
-	case Partial, Conjuncts:
+	case partial, conjuncts:
 		// TODO: remove this optimization or make it correct.
 		// No need to do further processing when we have errors and all values
 		// have been considered.
 		// TODO: is checkClosed really still necessary here?
-		if v.status == Conjuncts && (n.hasErr() || !n.checkClosed(state)) {
+		if v.status == conjuncts && (n.hasErr() || !n.checkClosed(state)) {
 			break
 		}
 
@@ -249,25 +249,25 @@ func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 
 		n.insertConjuncts(state)
 
-		v.status = Evaluating
+		v.status = evaluating
 
 		// Use maybeSetCache for cycle breaking
-		for n.maybeSetCache(); n.expandOne(Partial); n.maybeSetCache() {
+		for n.maybeSetCache(); n.expandOne(partial); n.maybeSetCache() {
 		}
 
 		n.doNotify()
 
 		if !n.done() {
 			switch {
-			case state < Conjuncts:
-				n.node.updateStatus(Partial)
+			case state < conjuncts:
+				n.node.updateStatus(partial)
 				return
 
-			case state == Conjuncts:
+			case state == conjuncts:
 				if err := n.incompleteErrors(true); err != nil && err.Code < CycleError {
 					n.node.AddErr(c, err)
 				} else {
-					n.node.updateStatus(Partial)
+					n.node.updateStatus(partial)
 				}
 				return
 			}
@@ -276,8 +276,8 @@ func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 		// Disjunctions should always be finalized. If there are nested
 		// disjunctions the last one should be finalized.
 		disState := state
-		if len(n.disjunctions) > 0 && disState != Finalized {
-			disState = Finalized
+		if len(n.disjunctions) > 0 && disState != finalized {
+			disState = finalized
 		}
 		n.expandDisjuncts(disState, n, maybeDefault, false, true)
 
@@ -339,25 +339,25 @@ func (c *OpContext) unify(v *Vertex, state VertexStatus) {
 
 		assertStructuralCycle(n)
 
-		if state != Finalized {
+		if state != finalized {
 			return
 		}
 
 		if v.BaseValue == nil {
-			v.BaseValue = n.getValidators(Finalized)
+			v.BaseValue = n.getValidators(finalized)
 		}
 
 		// Free memory here?
-		v.updateStatus(Finalized)
+		v.updateStatus(finalized)
 
-	case Finalized:
+	case finalized:
 	}
 }
 
 // insertConjuncts inserts conjuncts previously not inserted.
-func (n *nodeContext) insertConjuncts(state VertexStatus) bool {
+func (n *nodeContext) insertConjuncts(state vertexStatus) bool {
 	// Exit early if we have a concrete value and only need partial results.
-	if state == Partial {
+	if state == partial {
 		for n.conjunctsPos < len(n.conjuncts) {
 			c := n.conjuncts[n.conjunctsPos]
 			n.conjunctsPos++
@@ -376,7 +376,7 @@ func (n *nodeContext) insertConjuncts(state VertexStatus) bool {
 		// Intially request a Partial state to allow cyclic references to
 		// resolve more naturally first. This results in better error messages
 		// and less operations.
-		n.addExprConjunct(*p, Partial)
+		n.addExprConjunct(*p, partial)
 
 		// Record the OptionalTypes for all structs that were inferred by this
 		// Conjunct. This information can be used by algorithms such as trim.
@@ -435,7 +435,7 @@ func (n *nodeContext) doNotify() {
 	n.notify = n.notify[:0]
 }
 
-func (n *nodeContext) postDisjunct(state VertexStatus) {
+func (n *nodeContext) postDisjunct(state vertexStatus) {
 	ctx := n.ctx
 
 	for {
@@ -570,8 +570,8 @@ func (n *nodeContext) postDisjunct(state VertexStatus) {
 					}
 				}
 			}
-		} else if state == Finalized {
-			n.node.BaseValue = n.getValidators(Finalized)
+		} else if state == finalized {
+			n.node.BaseValue = n.getValidators(finalized)
 		}
 
 		if v == nil {
@@ -632,7 +632,7 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 		// }
 		// n := d.node.getNodeContext(ctx)
 		// n.addBottom(err)
-		if final && c.node != nil && c.node.status != Finalized {
+		if final && c.node != nil && c.node.status != finalized {
 			n := c.node.getNodeContext(n.ctx, 0)
 			n.addBottom(err)
 			c.node = nil
@@ -661,7 +661,7 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 		// }
 		// n := d.node.getNodeContext(ctx)
 		// n.addBottom(err)
-		if c.node != nil && c.node.status != Finalized {
+		if c.node != nil && c.node.status != finalized {
 			n := c.node.getNodeContext(n.ctx, 0)
 			n.addBottom(err)
 			c.node = nil
@@ -698,8 +698,8 @@ func (n *nodeContext) incompleteErrors(final bool) *Bottom {
 // have a discriminator field (e.g. Kubernetes). We should take care,
 // though, that any potential performance issues are eliminated for
 // Protobuf-like oneOf fields.
-func (n *nodeContext) checkClosed(state VertexStatus) bool {
-	ignore := state != Finalized || n.skipNonMonotonicChecks()
+func (n *nodeContext) checkClosed(state vertexStatus) bool {
+	ignore := state != finalized || n.skipNonMonotonicChecks()
 
 	v := n.node
 	if !v.Label.IsInt() && v.Parent != nil && !ignore && v.isDefined() {
@@ -717,7 +717,7 @@ func (n *nodeContext) checkClosed(state VertexStatus) bool {
 	return true
 }
 
-func (n *nodeContext) completeArcs(state VertexStatus) {
+func (n *nodeContext) completeArcs(state vertexStatus) {
 	if DebugSort > 0 {
 		DebugSortArcs(n.ctx, n.node)
 	}
@@ -731,16 +731,16 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 	// all arcs to be sure we get the correct result.
 	// For other cases we terminate early as this results in considerably
 	// better error messages.
-	if state <= Conjuncts &&
+	if state <= conjuncts &&
 		// Is allowed to go one step back. See Vertex.UpdateStatus.
 		n.node.status <= state+1 &&
 		(!n.node.hasVoidArc || n.node.ArcType == ArcMember) {
 
-		n.node.updateStatus(Conjuncts)
+		n.node.updateStatus(conjuncts)
 		return
 	}
 
-	n.node.updateStatus(EvaluatingArcs)
+	n.node.updateStatus(evaluatingArcs)
 
 	ctx := n.ctx
 
@@ -750,11 +750,11 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 		for _, a := range n.node.Arcs {
 			// Call UpdateStatus here to be absolutely sure the status is set
 			// correctly and that we are not regressing.
-			n.node.updateStatus(EvaluatingArcs)
+			n.node.updateStatus(evaluatingArcs)
 
 			wasVoid := a.ArcType == ArcVoid
 
-			ctx.unify(a, Finalized)
+			ctx.unify(a, finalized)
 
 			if a.ArcType == ArcVoid {
 				continue
@@ -764,8 +764,8 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 			// complete accordingly.
 			if !a.Label.IsLet() && a.ArcType == ArcMember {
 				// Don't set the state to Finalized if the child arcs are not done.
-				if state == Finalized && a.status < Finalized {
-					state = Conjuncts
+				if state == finalized && a.status < finalized {
+					state = conjuncts
 				}
 
 				if err, _ := a.BaseValue.(*Bottom); err != nil {
@@ -806,7 +806,7 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 			// TODO(errors): make Validate return bottom and generate
 			// optimized conflict message. Also track and inject IDs
 			// to determine origin location.s
-			v := ctx.evalState(c.expr, Finalized)
+			v := ctx.evalState(c.expr, finalized)
 			v, _ = ctx.getDefault(v)
 			v = Unwrap(v)
 
@@ -853,7 +853,7 @@ func (n *nodeContext) completeArcs(state VertexStatus) {
 	}
 	n.node.Structs = n.node.Structs[:k]
 
-	n.node.updateStatus(Finalized)
+	n.node.updateStatus(finalized)
 }
 
 // TODO: this is now a sentinel. Use a user-facing error that traces where
@@ -1099,7 +1099,7 @@ func (c *OpContext) newNodeContext(node *Vertex) *nodeContext {
 
 func (v *Vertex) getNodeContext(c *OpContext, ref int) *nodeContext {
 	if v.state == nil {
-		if v.status == Finalized {
+		if v.status == finalized {
 			return nil
 		}
 		v.state = c.newNodeContext(v)
@@ -1121,7 +1121,7 @@ func (v *Vertex) freeNode(n *nodeContext) {
 		panic("freeNode: nodeContext out of sync")
 	}
 	if n.refCount--; n.refCount == 0 {
-		if v.status == Finalized {
+		if v.status == finalized {
 			v.freeNodeState()
 		} else {
 			n.ctx.stats.Retained++
@@ -1277,7 +1277,7 @@ func (n *nodeContext) hasErr() bool {
 	if n.node.ChildErrors != nil {
 		return true
 	}
-	if n.node.Status() > Evaluating && n.node.IsErr() {
+	if n.node.status > evaluating && n.node.IsErr() {
 		return true
 	}
 	return n.ctx.HasErr() || n.errs != nil
@@ -1289,7 +1289,7 @@ func (n *nodeContext) getErr() *Bottom {
 }
 
 // getValidators sets the vertex' Value in case there was no concrete value.
-func (n *nodeContext) getValidators(state VertexStatus) BaseValue {
+func (n *nodeContext) getValidators(state vertexStatus) BaseValue {
 	ctx := n.ctx
 
 	a := []Value{}
@@ -1332,7 +1332,7 @@ func (n *nodeContext) getValidators(state VertexStatus) BaseValue {
 	switch len(a) {
 	case 0:
 		// Src is the combined input.
-		if state >= Conjuncts || n.kind&^CompositKind == 0 {
+		if state >= conjuncts || n.kind&^CompositKind == 0 {
 			v = &BasicType{K: n.kind}
 		}
 
@@ -1405,7 +1405,7 @@ func (n *nodeContext) addErr(err errors.Error) {
 // addExprConjuncts will attempt to evaluate an Expr and insert the value
 // into the nodeContext if successful or queue it for later evaluation if it is
 // incomplete or is not value.
-func (n *nodeContext) addExprConjunct(v Conjunct, state VertexStatus) {
+func (n *nodeContext) addExprConjunct(v Conjunct, state vertexStatus) {
 	env := v.Env
 	id := v.CloseInfo
 
@@ -1456,7 +1456,7 @@ func (n *nodeContext) addExprConjunct(v Conjunct, state VertexStatus) {
 
 // evalExpr is only called by addExprConjunct. If an error occurs, it records
 // the error in n and returns nil.
-func (n *nodeContext) evalExpr(v Conjunct, state VertexStatus) {
+func (n *nodeContext) evalExpr(v Conjunct, state vertexStatus) {
 	// Require an Environment.
 	ctx := n.ctx
 
@@ -1468,8 +1468,8 @@ func (n *nodeContext) evalExpr(v Conjunct, state VertexStatus) {
 		// later. For now we allow partial evaluation so that we can break
 		// cycles and postpone incomplete evaluations until more information is
 		// available down the line.
-		if state == Finalized {
-			state = Conjuncts
+		if state == finalized {
+			state = conjuncts
 		}
 		arc, err := ctx.resolveState(v, x, state)
 		if err != nil && (!err.IsIncomplete() || err.Permanent) {
@@ -1493,7 +1493,7 @@ func (n *nodeContext) evalExpr(v Conjunct, state VertexStatus) {
 		// A node should not Finalize itself as it may erase the state object
 		// which is still assumed to be present down the line
 		// (see https://cuelang.org/issues/2171).
-		if arc.status == Conjuncts && arc != n.node && arc.hasAllConjuncts {
+		if arc.status == conjuncts && arc != n.node && arc.hasAllConjuncts {
 			arc.Finalize(ctx)
 		}
 
@@ -1508,7 +1508,7 @@ func (n *nodeContext) evalExpr(v Conjunct, state VertexStatus) {
 	case Evaluator:
 		// Interpolation, UnaryExpr, BinaryExpr, CallExpr
 		// Could be unify?
-		val := ctx.evaluateRec(v, Partial)
+		val := ctx.evaluateRec(v, partial)
 		if b, ok := val.(*Bottom); ok &&
 			b.IsIncomplete() {
 			n.exprs = append(n.exprs, envExpr{v, b})
@@ -1580,10 +1580,10 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 	}
 	n.arcMap = append(n.arcMap, key)
 
-	status := arc.Status()
+	status := arc.status
 
 	switch status {
-	case Evaluating:
+	case evaluating:
 		// Reference cycle detected. We have reached a fixed point and
 		// adding conjuncts at this point will not change the value. Also,
 		// continuing to pursue this value will result in an infinite loop.
@@ -1598,7 +1598,7 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 			return
 		}
 
-	case EvaluatingArcs:
+	case evaluatingArcs:
 		// There is a structural cycle, but values may be processed nonetheless
 		// if there is a non-cyclic conjunct. See cycle.go.
 	}
@@ -1621,7 +1621,7 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 		// is necessary to prevent lookups in unevaluated structs.
 		// TODO(cycles): this can probably most easily be fixed with a
 		// having a more recursive implementation.
-		n.ctx.unify(arc, Partial)
+		n.ctx.unify(arc, partial)
 	}
 
 	// Don't add conjuncts if a node is referring to itself.
@@ -1638,7 +1638,7 @@ func (n *nodeContext) addVertexConjuncts(c Conjunct, arc *Vertex, inline bool) {
 		// closedness conflicts resulting from unifying the referenced arc were
 		// already caught there and that we can ignore further errors here.
 		c.CloseInfo = closeInfo
-		n.addExprConjunct(c, Partial)
+		n.addExprConjunct(c, partial)
 	}
 }
 
@@ -1688,7 +1688,7 @@ func (n *nodeContext) addValueConjunct(env *Environment, v Value, id CloseInfo) 
 
 			for _, c := range x.Conjuncts {
 				c.CloseInfo = id
-				n.addExprConjunct(c, Partial) // TODO: Pass from eval
+				n.addExprConjunct(c, partial) // TODO: Pass from eval
 			}
 			return
 		}
@@ -1927,7 +1927,7 @@ func (n *nodeContext) addStruct(
 			id := closeInfo.SpawnEmbed(x)
 
 			// push and opo embedding type.
-			n.addExprConjunct(MakeConjunct(childEnv, x, id), Partial)
+			n.addExprConjunct(MakeConjunct(childEnv, x, id), partial)
 
 		case *BulkOptionalField, *Ellipsis:
 			// Nothing to do here. Note that the presence of these fields do not
@@ -1990,7 +1990,7 @@ func (n *nodeContext) insertField(f Feature, mode ArcType, x Conjunct) *Vertex {
 	case arc.state != nil:
 		arc.state.addConjunctDynamic(x)
 
-	case arc.Status() == 0:
+	case arc.IsUnprocessed():
 		arc.addConjunctUnchecked(x)
 
 	default:
@@ -2017,7 +2017,7 @@ func (n *nodeContext) insertField(f Feature, mode ArcType, x Conjunct) *Vertex {
 // This seems to be too complicated and lead to iffy edge cases.
 // TODO(errors): detect when a field is added to a struct that is already used
 // in a for clause.
-func (n *nodeContext) expandOne(state VertexStatus) (done bool) {
+func (n *nodeContext) expandOne(state vertexStatus) (done bool) {
 	// Don't expand incomplete expressions if we detected a cycle.
 	if n.done() || (n.hasCycle && !n.hasNonCycle) {
 		return false
@@ -2064,7 +2064,7 @@ func (n *nodeContext) injectDynamic() (progress bool) {
 		x := d.field.Key
 		// Push state to capture and remove errors.
 		s := ctx.PushState(d.env, x.Source())
-		v := ctx.evalState(x, Finalized)
+		v := ctx.evalState(x, finalized)
 		b := ctx.PopState(s)
 
 		if b != nil && b.IsIncomplete() {
@@ -2176,7 +2176,7 @@ outer:
 		for j, elem := range l.list.Elems {
 			switch x := elem.(type) {
 			case *Comprehension:
-				err := c.yield(nil, l.env, x, Finalized, func(e *Environment) {
+				err := c.yield(nil, l.env, x, finalized, func(e *Environment) {
 					label, err := MakeLabel(x.Source(), index, IntLabel)
 					n.addErr(err)
 					index++
@@ -2287,7 +2287,7 @@ outer:
 	}
 
 	if m, ok := n.node.BaseValue.(*ListMarker); !ok {
-		n.node.setValue(c, Partial, &ListMarker{
+		n.node.setValue(c, partial, &ListMarker{
 			Src:    ast.NewBinExpr(token.AND, sources...),
 			IsOpen: isOpen,
 		})

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -1906,7 +1906,7 @@ func (n *nodeContext) addStruct(
 
 	for _, d := range s.Decls {
 		switch x := d.(type) {
-		case *Field, *OptionalField, *LetField:
+		case *Field, *LetField:
 			// handle in next iteration.
 
 		case *DynamicField:
@@ -1947,14 +1947,11 @@ func (n *nodeContext) addStruct(
 	for _, d := range s.Decls {
 		switch x := d.(type) {
 		case *Field:
-			if x.Label.IsString() {
+			if x.Label.IsString() && x.ArcType == ArcMember {
 				n.aStruct = s
 				n.aStructID = closeInfo
 			}
-			n.insertField(x.Label, ArcMember, MakeConjunct(childEnv, x, closeInfo))
-
-		case *OptionalField:
-			n.insertField(x.Label, ArcOptional, MakeConjunct(childEnv, x, closeInfo))
+			n.insertField(x.Label, x.ArcType, MakeConjunct(childEnv, x, closeInfo))
 
 		case *LetField:
 			arc := n.insertField(x.Label, ArcMember, MakeConjunct(childEnv, x, closeInfo))

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -2009,6 +2009,17 @@ func (n *nodeContext) insertField(f Feature, mode ArcType, x Conjunct) *Vertex {
 	return arc
 }
 
+func (n *nodeContext) insertFieldUnchecked(f Feature, mode ArcType, x Conjunct) *Vertex {
+	ctx := n.ctx
+	arc, isNew := n.node.GetArc(ctx, f, mode)
+	if f.IsLet() && !isNew {
+		arc.MultiLet = true
+		return arc
+	}
+	arc.addConjunctUnchecked(x)
+	return arc
+}
+
 // expandOne adds dynamic fields to a node until a fixed point is reached.
 // On each iteration, dynamic fields that cannot resolve due to incomplete
 // values are skipped. They will be retried on the next iteration until no

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1909,7 +1909,7 @@ func (x *ForClause) yield(s *compState) {
 			v := &Vertex{Label: x.Key}
 			key := a.Label.ToValue(c)
 			v.AddConjunct(MakeRootConjunct(c.Env(0), key))
-			v.SetValue(c, Finalized, key)
+			v.SetValue(c, key)
 			n.Arcs = append(n.Arcs, v)
 		}
 

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -252,13 +252,11 @@ func (x *Ellipsis) Source() ast.Node {
 //	"\(expr)": expr
 //	(expr): expr
 type DynamicField struct {
-	Src   *ast.Field
-	Key   Expr
-	Value Expr
-}
+	Src *ast.Field
 
-func (x *DynamicField) IsOptional() bool {
-	return x.Src.Optional != token.NoPos
+	ArcType ArcType
+	Key     Expr
+	Value   Expr
 }
 
 func (x *DynamicField) Source() ast.Node {

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -102,13 +102,9 @@ func (o *StructLit) Init() {
 			if o.fieldIndex(x.Label) < 0 {
 				o.Fields = append(o.Fields, FieldInfo{Label: x.Label})
 			}
-
-		case *OptionalField:
-			p := o.fieldIndex(x.Label)
-			if p < 0 {
-				o.Fields = append(o.Fields, FieldInfo{Label: x.Label})
+			if x.ArcType > ArcMember {
+				o.types |= HasField
 			}
-			o.types |= HasField
 
 		case *LetField:
 			if o.fieldIndex(x.Label) >= 0 {
@@ -174,8 +170,8 @@ func (o *StructLit) OptionalTypes() OptionalType {
 // Fields can also be used as expressions whereby the value field is the
 // expression this allows retaining more context.
 
-// Field represents a field with a fixed label. It can be a regular field,
-// definition or hidden field.
+// Field represents a regular field or field constraint with a fixed label.
+// The label can be a regular field, definition or hidden field.
 //
 //	foo: bar
 //	#foo: bar
@@ -187,27 +183,12 @@ func (o *StructLit) OptionalTypes() OptionalType {
 type Field struct {
 	Src *ast.Field
 
-	Label Feature
-	Value Expr
+	ArcType ArcType
+	Label   Feature
+	Value   Expr
 }
 
 func (x *Field) Source() ast.Node {
-	if x.Src == nil {
-		return nil
-	}
-	return x.Src
-}
-
-// An OptionalField represents an optional regular field.
-//
-//	foo?: expr
-type OptionalField struct {
-	Src   *ast.Field
-	Label Feature
-	Value Expr
-}
-
-func (x *OptionalField) Source() ast.Node {
 	if x.Src == nil {
 		return nil
 	}
@@ -1821,6 +1802,9 @@ type Comprehension struct {
 	// rather than an Expr, in the latter case to preserve as much position
 	// information as possible.
 	Value Node
+
+	// The type of field as which the comprehension is added.
+	arcType ArcType
 
 	// Only used for partial comprehensions.
 	comp   *envComprehension

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1277,8 +1277,8 @@ func (x *BinaryExpr) evaluate(c *OpContext, state vertexStatus) Value {
 		}
 	}
 
-	left, _ := c.Concrete(env, x.X, x.Op)
-	right, _ := c.Concrete(env, x.Y, x.Op)
+	left, _ := c.concrete(env, x.X, x.Op)
+	right, _ := c.concrete(env, x.Y, x.Op)
 
 	if err := CombineErrors(x.Src, left, right); err != nil {
 		return err

--- a/internal/core/adt/expr_test.go
+++ b/internal/core/adt/expr_test.go
@@ -55,7 +55,6 @@ func TestNilSource(t *testing.T) {
 		&NodeLink{},
 		&Null{},
 		&Num{},
-		&OptionalField{},
 		&SelectorExpr{},
 		&SliceExpr{},
 		&String{},

--- a/internal/core/compile/builtin.go
+++ b/internal/core/compile/builtin.go
@@ -143,7 +143,7 @@ var orBuiltin = &adt.Builtin{
 			&adt.DisjunctionExpr{Values: d, HasDefaults: false},
 			closeInfo,
 		))
-		c.Unify(v, adt.Conjuncts)
+		v.CompleteArcs(c)
 		return v
 	},
 }

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -626,17 +626,23 @@ func (c *compiler) decl(d ast.Decl) adt.Decl {
 			}
 
 		case *ast.ParenExpr:
+			t, _ := internal.ConstraintToken(x)
+
 			return &adt.DynamicField{
-				Src:   x,
-				Key:   c.expr(l),
-				Value: value,
+				Src:     x,
+				Key:     c.expr(l),
+				ArcType: adt.ConstraintFromToken(t),
+				Value:   value,
 			}
 
 		case *ast.Interpolation:
+			t, _ := internal.ConstraintToken(x)
+
 			return &adt.DynamicField{
-				Src:   x,
-				Key:   c.expr(l),
-				Value: value,
+				Src:     x,
+				Key:     c.expr(l),
+				ArcType: adt.ConstraintFromToken(t),
+				Value:   value,
 			}
 		}
 

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -595,14 +595,12 @@ func (c *compiler) decl(d ast.Decl) adt.Decl {
 				return c.errf(x, "cannot use _ as label")
 			}
 
-			t := adt.ArcMember
-			if x.Optional != token.NoPos {
-				t = adt.ArcOptional
-			}
+			t, _ := internal.ConstraintToken(x)
+
 			return &adt.Field{
 				Src:     x,
 				Label:   label,
-				ArcType: t,
+				ArcType: adt.ConstraintFromToken(t),
 				Value:   value,
 			}
 

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -595,18 +595,15 @@ func (c *compiler) decl(d ast.Decl) adt.Decl {
 				return c.errf(x, "cannot use _ as label")
 			}
 
-			if x.Optional == token.NoPos {
-				return &adt.Field{
-					Src:   x,
-					Label: label,
-					Value: value,
-				}
-			} else {
-				return &adt.OptionalField{
-					Src:   x,
-					Label: label,
-					Value: value,
-				}
+			t := adt.ArcMember
+			if x.Optional != token.NoPos {
+				t = adt.ArcOptional
+			}
+			return &adt.Field{
+				Src:     x,
+				Label:   label,
+				ArcType: t,
+				Value:   value,
 			}
 
 		case *ast.ListLit:

--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -33,6 +33,7 @@ import (
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/parser"
 	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal"
 	"cuelang.org/go/internal/core/adt"
 	"cuelang.org/go/internal/core/compile"
 	"cuelang.org/go/internal/types"
@@ -694,7 +695,7 @@ func goTypeToValueRec(ctx *adt.OpContext, allowNullDefault bool, t reflect.Type)
 			// The GO JSON decoder always allows a value to be undefined.
 			d := &ast.Field{Label: ast.NewIdent(name), Value: elem}
 			if isOptional(&f) {
-				d.Optional = token.Blank.Pos()
+				internal.SetConstraint(d, token.OPTION)
 			}
 			obj.Elts = append(obj.Elts, d)
 		}

--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -414,7 +414,7 @@ func convertRec(ctx *adt.OpContext, nilIsTop bool, x interface{}) adt.Value {
 			// There is no closedness or cycle info for Go structs, so we
 			// pass an empty CloseInfo.
 			v.AddStruct(obj, env, adt.CloseInfo{})
-			v.SetValue(ctx, adt.Finalized, &adt.StructMarker{})
+			v.SetValue(ctx, &adt.StructMarker{})
 
 			t := value.Type()
 			for i := 0; i < value.NumField(); i++ {
@@ -464,7 +464,7 @@ func convertRec(ctx *adt.OpContext, nilIsTop bool, x interface{}) adt.Value {
 					arc.Label = f
 				} else {
 					arc = &adt.Vertex{Label: f, BaseValue: sub}
-					arc.UpdateStatus(adt.Finalized)
+					arc.ForceDone()
 					arc.AddConjunct(adt.MakeRootConjunct(nil, sub))
 				}
 				v.Arcs = append(v.Arcs, arc)
@@ -474,7 +474,7 @@ func convertRec(ctx *adt.OpContext, nilIsTop bool, x interface{}) adt.Value {
 
 		case reflect.Map:
 			v := &adt.Vertex{BaseValue: &adt.StructMarker{}}
-			v.SetValue(ctx, adt.Finalized, &adt.StructMarker{})
+			v.SetValue(ctx, &adt.StructMarker{})
 
 			t := value.Type()
 			switch key := t.Key(); key.Kind() {
@@ -518,7 +518,7 @@ func convertRec(ctx *adt.OpContext, nilIsTop bool, x interface{}) adt.Value {
 						arc.Label = f
 					} else {
 						arc = &adt.Vertex{Label: f, BaseValue: sub}
-						arc.UpdateStatus(adt.Finalized)
+						arc.ForceDone()
 						arc.AddConjunct(adt.MakeRootConjunct(nil, sub))
 					}
 					v.Arcs = append(v.Arcs, arc)

--- a/internal/core/debug/compact.go
+++ b/internal/core/debug/compact.go
@@ -64,9 +64,7 @@ func (w *compactPrinter) node(n adt.Node) {
 					w.node(a)
 				} else {
 					w.label(a.Label)
-					if a.IsConstraint() {
-						w.string("?")
-					}
+					w.string(a.ArcType.Suffix())
 					w.string(":")
 					w.node(a)
 				}
@@ -116,13 +114,8 @@ func (w *compactPrinter) node(n adt.Node) {
 	case *adt.Field:
 		s := w.labelString(x.Label)
 		w.string(s)
+		w.string(x.ArcType.Suffix())
 		w.string(":")
-		w.node(x.Value)
-
-	case *adt.OptionalField:
-		s := w.labelString(x.Label)
-		w.string(s)
-		w.string("?:")
 		w.node(x.Value)
 
 	case *adt.LetField:

--- a/internal/core/debug/compact.go
+++ b/internal/core/debug/compact.go
@@ -136,9 +136,7 @@ func (w *compactPrinter) node(n adt.Node) {
 
 	case *adt.DynamicField:
 		w.node(x.Key)
-		if x.IsOptional() {
-			w.string("?")
-		}
+		w.string(x.ArcType.Suffix())
 		w.string(":")
 		w.node(x.Value)
 

--- a/internal/core/debug/debug.go
+++ b/internal/core/debug/debug.go
@@ -318,9 +318,7 @@ func (w *printer) node(n adt.Node) {
 
 	case *adt.DynamicField:
 		w.node(x.Key)
-		if x.IsOptional() {
-			w.string("?")
-		}
+		w.string(x.ArcType.Suffix())
 		w.string(": ")
 		w.node(x.Value)
 

--- a/internal/core/debug/debug.go
+++ b/internal/core/debug/debug.go
@@ -27,7 +27,6 @@ import (
 
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/literal"
-	"cuelang.org/go/internal"
 	"cuelang.org/go/internal/core/adt"
 )
 
@@ -237,9 +236,7 @@ func (w *printer) node(n adt.Node) {
 			} else {
 				w.string("\n")
 				w.label(a.Label)
-				if a.IsConstraint() {
-					w.string("?")
-				}
+				w.string(a.ArcType.Suffix())
 				w.string(": ")
 				w.node(a)
 			}
@@ -298,20 +295,8 @@ func (w *printer) node(n adt.Node) {
 	case *adt.Field:
 		s := w.labelString(x.Label)
 		w.string(s)
+		w.string(x.ArcType.Suffix())
 		w.string(":")
-		if x.Label.IsDef() && !internal.IsDef(s) {
-			w.string(":")
-		}
-		w.string(" ")
-		w.node(x.Value)
-
-	case *adt.OptionalField:
-		s := w.labelString(x.Label)
-		w.string(s)
-		w.string("?:")
-		if x.Label.IsDef() && !internal.IsDef(s) {
-			w.string(":")
-		}
 		w.string(" ")
 		w.node(x.Value)
 

--- a/internal/core/dep/dep.go
+++ b/internal/core/dep/dep.go
@@ -97,7 +97,7 @@ var empty *adt.Vertex
 func init() {
 	// TODO: Consider setting a non-nil BaseValue.
 	empty = &adt.Vertex{}
-	empty.UpdateStatus(adt.Finalized)
+	empty.ForceDone()
 }
 
 func visit(c *adt.OpContext, n *adt.Vertex, f VisitFunc, all, top bool) (err error) {

--- a/internal/core/dep/dep.go
+++ b/internal/core/dep/dep.go
@@ -291,11 +291,6 @@ func (c *visitor) markDecl(env *adt.Environment, d adt.Decl) {
 	case *adt.Field:
 		c.markSubExpr(env, x.Value)
 
-	case *adt.OptionalField:
-		// when dynamic, only continue if there is evidence of
-		// the field in the parallel actual evaluation.
-		c.markSubExpr(env, x.Value)
-
 	case *adt.BulkOptionalField:
 		c.markExpr(env, x.Filter)
 		// when dynamic, only continue if there is evidence of

--- a/internal/core/dep/mixed.go
+++ b/internal/core/dep/mixed.go
@@ -82,9 +82,6 @@ func (m marked) markExpr(x adt.Expr) {
 			case *adt.Field:
 				m.markExpr(x.Value)
 
-			case *adt.OptionalField:
-				m.markExpr(x.Value)
-
 			case *adt.BulkOptionalField:
 				m.markExpr(x.Value)
 

--- a/internal/core/eval/eval.go
+++ b/internal/core/eval/eval.go
@@ -28,7 +28,7 @@ func Evaluate(r adt.Runtime, v *adt.Vertex) {
 		Runtime: r,
 		Format:  format,
 	})
-	c.Unify(v, adt.Finalized)
+	v.Finalize(c)
 }
 
 func New(r adt.Runtime) *Unifier {
@@ -38,10 +38,6 @@ func New(r adt.Runtime) *Unifier {
 type Unifier struct {
 	r adt.Runtime
 	e *adt.OpContext
-}
-
-func (e *Unifier) Unify(ctx *adt.OpContext, v *adt.Vertex, state adt.VertexStatus) {
-	e.e.Unify(v, state)
 }
 
 func (e *Unifier) Stats() *stats.Counts {

--- a/internal/core/export/adt.go
+++ b/internal/core/export/adt.go
@@ -420,21 +420,10 @@ func (e *exporter) decl(env *adt.Environment, d adt.Decl) ast.Decl {
 		f := &ast.Field{
 			Label: e.stringLabel(x.Label),
 		}
-
-		e.setField(x.Label, f)
-
-		f.Value = e.expr(env, x.Value)
-		f.Attrs = extractFieldAttrs(nil, x)
-
-		return f
-
-	case *adt.OptionalField:
-		e.setDocs(x)
-		f := &ast.Field{
-			Label:    e.stringLabel(x.Label),
-			Optional: token.NoSpace.Pos(),
+		if x.ArcType != adt.ArcMember {
+			// Backwards compatibility.
+			f.Optional = token.NoSpace.Pos()
 		}
-
 		e.setField(x.Label, f)
 
 		f.Value = e.expr(env, x.Value)

--- a/internal/core/export/adt.go
+++ b/internal/core/export/adt.go
@@ -467,6 +467,7 @@ func (e *exporter) decl(env *adt.Environment, d adt.Decl) ast.Decl {
 		srcKey := x.Key
 
 		f := &ast.Field{}
+		internal.SetConstraint(f, x.ArcType.Token())
 
 		v, _ := e.ctx.Evaluate(env, x.Key)
 

--- a/internal/core/export/adt.go
+++ b/internal/core/export/adt.go
@@ -23,6 +23,7 @@ import (
 	"cuelang.org/go/cue/ast/astutil"
 	"cuelang.org/go/cue/literal"
 	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal"
 	"cuelang.org/go/internal/core/adt"
 )
 
@@ -420,10 +421,7 @@ func (e *exporter) decl(env *adt.Environment, d adt.Decl) ast.Decl {
 		f := &ast.Field{
 			Label: e.stringLabel(x.Label),
 		}
-		if x.ArcType != adt.ArcMember {
-			// Backwards compatibility.
-			f.Optional = token.NoSpace.Pos()
-		}
+		internal.SetConstraint(f, x.ArcType.Token())
 		e.setField(x.Label, f)
 
 		f.Value = e.expr(env, x.Value)

--- a/internal/core/export/export_test.go
+++ b/internal/core/export/export_test.go
@@ -213,7 +213,7 @@ func TestGenerated(t *testing.T) {
 	}, {
 		in: func(r *adt.OpContext) (adt.Expr, error) {
 			v := &adt.Vertex{}
-			v.SetValue(r, adt.Finalized, &adt.StructMarker{})
+			v.SetValue(r, &adt.StructMarker{})
 			return v, nil
 		},
 		out: ``, // empty file

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -53,7 +53,7 @@ var empty *adt.Vertex
 func init() {
 	// TODO: Consider setting a non-nil BaseValue.
 	empty = &adt.Vertex{}
-	empty.UpdateStatus(adt.Finalized)
+	empty.ForceDone()
 }
 
 // innerExpr is like expr, but prohibits inlining in certain cases.

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -20,6 +20,7 @@ import (
 
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal"
 	"cuelang.org/go/internal/core/adt"
 )
 
@@ -156,6 +157,7 @@ func (x *exporter) mergeValues(label adt.Feature, src *adt.Vertex, a []conjunct,
 		for _, a := range src.Arcs {
 			if x, ok := e.fields[a.Label]; ok {
 				x.arc = a
+				x.arcType = a.ArcType
 				e.fields[a.Label] = x
 			}
 		}
@@ -232,7 +234,7 @@ func (x *exporter) mergeValues(label adt.Feature, src *adt.Vertex, a []conjunct,
 		if f.IsLet() {
 			continue
 		}
-		field := e.fields[f]
+		field := e.getField(f)
 		c := field.conjuncts
 
 		label := e.stringLabel(f)
@@ -261,9 +263,7 @@ func (x *exporter) mergeValues(label adt.Feature, src *adt.Vertex, a []conjunct,
 			x.inDefinition--
 		}
 
-		if isOptional(a) {
-			d.Optional = token.Blank.Pos()
-		}
+		internal.SetConstraint(d, field.arcType.Token())
 		if x.cfg.ShowDocs {
 			docs := extractDocs(src, a)
 			ast.SetComments(d, docs)
@@ -317,6 +317,14 @@ type conjuncts struct {
 	isData bool
 }
 
+func (c *conjuncts) getField(label adt.Feature) field {
+	f, ok := c.fields[label]
+	if !ok {
+		f.arcType = adt.ArcVoid
+	}
+	return f
+}
+
 func (c *conjuncts) addValueConjunct(src *adt.Vertex, env *adt.Environment, x adt.Elem) {
 	switch b, ok := x.(adt.BaseValue); {
 	case ok && src != nil && isTop(b) && !isTop(src.BaseValue):
@@ -326,8 +334,12 @@ func (c *conjuncts) addValueConjunct(src *adt.Vertex, env *adt.Environment, x ad
 	}
 }
 
-func (c *conjuncts) addConjunct(f adt.Feature, env *adt.Environment, n adt.Node) {
-	x := c.fields[f]
+func (c *conjuncts) addConjunct(f adt.Feature, t adt.ArcType, env *adt.Environment, n adt.Node) {
+	x := c.getField(f)
+	if t < x.arcType {
+		x.arcType = t
+	}
+
 	v := adt.MakeRootConjunct(env, n)
 	x.conjuncts = append(x.conjuncts, conjunct{
 		c:  v,
@@ -338,6 +350,7 @@ func (c *conjuncts) addConjunct(f adt.Feature, env *adt.Environment, n adt.Node)
 }
 
 type field struct {
+	arcType   adt.ArcType
 	docs      []*ast.CommentGroup
 	arc       *adt.Vertex
 	conjuncts []conjunct
@@ -372,9 +385,11 @@ func (e *conjuncts) addExpr(env *adt.Environment, src *adt.Vertex, x adt.Elem, i
 
 		for _, d := range x.Decls {
 			var label adt.Feature
+			t := adt.ArcVoid
 			switch f := d.(type) {
 			case *adt.Field:
 				label = f.Label
+				t = f.ArcType
 				// TODO: mark optional here, if needed.
 			case *adt.LetField:
 				continue
@@ -389,7 +404,7 @@ func (e *conjuncts) addExpr(env *adt.Environment, src *adt.Vertex, x adt.Elem, i
 			default:
 				panic(fmt.Sprintf("Unexpected type %T", d))
 			}
-			e.addConjunct(label, env, d)
+			e.addConjunct(label, t, env, d)
 		}
 		e.top().upCount--
 
@@ -428,7 +443,7 @@ func (e *conjuncts) addExpr(env *adt.Environment, src *adt.Vertex, x adt.Elem, i
 						continue
 					}
 
-					e.addConjunct(a.Label, env, a)
+					e.addConjunct(a.Label, a.ArcType, env, a)
 				}
 			}
 		}
@@ -471,28 +486,6 @@ func isTop(x adt.BaseValue) bool {
 	default:
 		return false
 	}
-}
-
-// TODO: find a better way to annotate optionality. Maybe a special conjunct
-// or store it in the field information?
-func isOptional(a []adt.Conjunct) bool {
-	if len(a) == 0 {
-		return false
-	}
-	for _, c := range a {
-		if v, ok := c.Elem().(*adt.Vertex); ok && !v.IsData() && len(v.Conjuncts) > 0 {
-			return isOptional(v.Conjuncts)
-		}
-		switch f := c.Source().(type) {
-		case nil:
-			return false
-		case *ast.Field:
-			if f.Optional == token.NoPos {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 func isComplexStruct(s *adt.StructLit) bool {

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -375,9 +375,7 @@ func (e *conjuncts) addExpr(env *adt.Environment, src *adt.Vertex, x adt.Elem, i
 			switch f := d.(type) {
 			case *adt.Field:
 				label = f.Label
-			case *adt.OptionalField:
-				// TODO: mark optional here.
-				label = f.Label
+				// TODO: mark optional here, if needed.
 			case *adt.LetField:
 				continue
 			case *adt.Ellipsis:
@@ -503,13 +501,6 @@ func isComplexStruct(s *adt.StructLit) bool {
 		case *adt.Field:
 			// TODO: remove this and also handle field annotation in expr().
 			// This allows structs to be merged. Ditto below.
-			if x.Src != nil {
-				if _, ok := x.Src.Label.(*ast.Alias); ok {
-					return ok
-				}
-			}
-
-		case *adt.OptionalField:
 			if x.Src != nil {
 				if _, ok := x.Src.Label.(*ast.Alias); ok {
 					return ok

--- a/internal/core/export/self.go
+++ b/internal/core/export/self.go
@@ -181,7 +181,7 @@ func (p *pivotter) markDeps(v *adt.Vertex) {
 				return nil
 			}
 
-		case node.Status() == adt.Unprocessed:
+		case node.IsUnprocessed():
 			// This may happen for DynamicReferences.
 			return nil
 		}

--- a/internal/core/export/testdata/main/adt.txtar
+++ b/internal/core/export/testdata/main/adt.txtar
@@ -81,6 +81,9 @@ m1: {[string]: uint} & {
 	// bar is a field
 	bar: 4
 
+	// baz is a required field.
+	baz!: 5
+
 	// a comment too many.
 
 	...
@@ -208,6 +211,9 @@ m1:  {
 
 	// bar is a field
 	bar: 4
+
+	// baz is a required field.
+	baz!: 5
 	...
 }
 
@@ -299,6 +305,9 @@ errorListDef: {
 
 [m1 bar]
 - bar is a field
+
+[m1 baz]
+- baz is a required field.
 
 [y1]
 [y1 src]
@@ -396,6 +405,9 @@ _|_ // e3: index out of range [2] with length 2
 
 		// bar is a field
 		bar: 4
+
+		// baz is a required field.
+		baz!: 5
 	}
 	y1: {
 		src: [1, 2, 3]

--- a/internal/core/export/testdata/main/def.txtar
+++ b/internal/core/export/testdata/main/def.txtar
@@ -2,17 +2,27 @@
 a:  int | *2
 b?: 4 | 5
 c: [string]: int
+
+#d: {
+	e!: string
+	e?: =~"a"
+}
 -- out/definition --
 a:  int | *2
 b?: 4 | 5
 c: {
 	[string]: int
 }
+#d: {
+	e!: =~"a"
+}
 -- out/doc --
 []
 [a]
 [b]
 [c]
+[#d]
+[#d e]
 -- out/value --
 == Simplified
 {
@@ -24,6 +34,9 @@ c: {
 	a:  *2 | int
 	b?: 4 | 5
 	c: {}
+	#d: {
+		e!: =~"a"
+	}
 }
 == Final
 {
@@ -35,10 +48,16 @@ c: {
 	a:  *2 | int
 	b?: 4 | 5
 	c: {}
+	#d: {
+		e!: =~"a"
+	}
 }
 == Eval
 {
 	a:  2
 	b?: 4 | 5
 	c: {}
+	#d: {
+		e!: =~"a"
+	}
 }

--- a/internal/core/export/testdata/main/dynamic.txtar
+++ b/internal/core/export/testdata/main/dynamic.txtar
@@ -9,6 +9,14 @@ a: {
 	labelZ: Z
 }
 E=["cue"]: name: E | null
+
+q: "q"
+q1: "q1"
+r: "r"
+r1: "r1"
+("s-"+q)?: 1
+("s-"+r)!: 2
+("s-"+q1)?: (r1)!: 3
 -- out/definition --
 x:     string
 X=(x): 4
@@ -22,6 +30,15 @@ a: {
 E=["cue"]: {
 	name: E | null
 }
+q:      "q"
+q1:     "q1"
+r:      "r"
+r1:     "r1"
+"s-q"?: 1
+"s-r"!: 2
+"s-q1"?: {
+	(r1)!: 3
+}
 -- out/doc --
 []
 [x]
@@ -29,8 +46,16 @@ E=["cue"]: {
 [a labelX]
 [a labelY]
 [a labelZ]
+[q]
+[q1]
+[r]
+[r1]
 [_]
 [y]
+["s-q"]
+["s-r"]
+["s-q1"]
+["s-q1" r1]
 -- out/value --
 == Simplified
 _|_ // invalid non-ground value string (must be concrete string) (and 1 more errors)

--- a/internal/core/export/toposort.go
+++ b/internal/core/export/toposort.go
@@ -92,9 +92,6 @@ func extractFeatures(in []*adt.StructInfo) (a [][]adt.Feature) {
 			switch x := e.(type) {
 			case *adt.Field:
 				sorted = append(sorted, x.Label)
-
-			case *adt.OptionalField:
-				sorted = append(sorted, x.Label)
 			}
 		}
 

--- a/internal/core/export/value.go
+++ b/internal/core/export/value.go
@@ -22,6 +22,7 @@ import (
 	"cuelang.org/go/cue/ast/astutil"
 	"cuelang.org/go/cue/literal"
 	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal"
 	"cuelang.org/go/internal/core/adt"
 )
 
@@ -441,7 +442,7 @@ func (e *exporter) structComposite(v *adt.Vertex, attrs []*ast.Attribute) ast.Ex
 			if !p.ShowOptional {
 				continue
 			}
-			f.Optional = token.NoSpace.Pos()
+			internal.SetConstraint(f, arc.ArcType.Token())
 		}
 
 		f.Value = e.vertex(arc)

--- a/internal/core/subsume/structural.go
+++ b/internal/core/subsume/structural.go
@@ -250,12 +250,9 @@ func (c *collatedDecls) collate(env *adt.Environment, s *adt.StructLit) {
 			e.required = true
 			e.conjuncts = append(e.conjuncts, adt.MakeRootConjunct(env, x))
 			c.fields[x.Label] = e
-
-		case *adt.OptionalField:
-			e := c.fields[x.Label]
-			e.conjuncts = append(e.conjuncts, adt.MakeRootConjunct(env, x))
-			c.fields[x.Label] = e
-			c.hasOptional = true
+			if x.ArcType != adt.ArcMember {
+				c.hasOptional = true
+			}
 
 		case *adt.BulkOptionalField:
 			c.pattern = append(c.pattern, x)

--- a/internal/core/validate/validate.go
+++ b/internal/core/validate/validate.go
@@ -98,6 +98,16 @@ func (v *validator) validate(x *adt.Vertex) {
 	}
 
 	for _, a := range x.Arcs {
+		if a.ArcType == adt.ArcRequired && v.inDefinition == 0 {
+			saved := v.ctx.PushArc(a)
+			v.add(&adt.Bottom{
+				Code: adt.IncompleteError,
+				Err:  v.ctx.Newf("field is required but not present"),
+			})
+			v.ctx.PopArc(saved)
+			continue
+		}
+
 		if a.Label.IsLet() || !a.IsDefined(v.ctx) {
 			continue
 		}

--- a/internal/core/validate/validate_test.go
+++ b/internal/core/validate/validate_test.go
@@ -196,7 +196,7 @@ y: conflicting values 4 and 2:
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx.Unify(v, adt.Finalized)
+			v.Finalize(ctx)
 			if tc.lookup != "" {
 				v = v.Lookup(adt.MakeIdentLabel(r, tc.lookup, "main"))
 			}

--- a/internal/core/walk/walk.go
+++ b/internal/core/walk/walk.go
@@ -140,10 +140,6 @@ func (w *Visitor) node(n adt.Node) {
 		w.feature(x.Label, x)
 		w.node(x.Value)
 
-	case *adt.OptionalField:
-		w.feature(x.Label, x)
-		w.node(x.Value)
-
 	case *adt.LetField:
 		w.feature(x.Label, x)
 		w.node(x.Value)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -345,6 +345,30 @@ func IsRegularField(f *ast.Field) bool {
 	return true
 }
 
+// ConstraintToken reports which constraint token (? or !) is associated
+// with a field (if any), taking into account compatibility of deprecated
+// fields.
+func ConstraintToken(f *ast.Field) (t token.Token, ok bool) {
+	if f.Constraint != token.ILLEGAL {
+		return f.Constraint, true
+	}
+	if f.Optional != token.NoPos {
+		return token.OPTION, true
+	}
+	return f.Constraint, false
+}
+
+// SetConstraints sets both the main and deprecated fields of f according to the
+// given constraint token.
+func SetConstraint(f *ast.Field, t token.Token) {
+	f.Constraint = t
+	if t == token.ILLEGAL {
+		f.Optional = token.NoPos
+	} else {
+		f.Optional = token.Blank.Pos()
+	}
+}
+
 func EmbedStruct(s *ast.StructLit) *ast.EmbedDecl {
 	e := &ast.EmbedDecl{Expr: s}
 	if len(s.Elts) == 1 {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -51,7 +51,7 @@ func Make(ctx *adt.OpContext, v adt.Value) cue.Value {
 func MakeError(r *runtime.Runtime, err errors.Error) cue.Value {
 	b := &adt.Bottom{Err: err}
 	node := &adt.Vertex{BaseValue: b}
-	node.UpdateStatus(adt.Finalized)
+	node.ForceDone()
 	node.AddConjunct(adt.MakeRootConjunct(nil, b))
 	return (*cue.Context)(r).Encode(node)
 }

--- a/pkg/internal/builtin.go
+++ b/pkg/internal/builtin.go
@@ -101,7 +101,7 @@ func (p *Package) MustCompile(ctx *adt.OpContext, importPath string) *adt.Vertex
 
 	// We could compile lazily, but this is easier for debugging.
 	obj.Finalize(ctx)
-	if err := obj.Err(ctx, adt.Finalized); err != nil {
+	if err := obj.Err(ctx); err != nil {
 		panic(err.Err)
 	}
 

--- a/pkg/internal/context.go
+++ b/pkg/internal/context.go
@@ -62,7 +62,7 @@ func (c *CallCtxt) Struct(i int) Struct {
 	x := c.args[i]
 	switch v, ok := x.(*adt.Vertex); {
 	case ok && !v.IsList():
-		c.ctx.Unify(v, adt.Conjuncts)
+		v.CompleteArcs(c.ctx)
 		return Struct{c.ctx, v}
 
 	case v != nil:

--- a/pkg/list/sort.go
+++ b/pkg/list/sort.go
@@ -112,7 +112,7 @@ func makeValueSorter(list []cue.Value, cmp cue.Value) (s valueSorter) {
 		Parent:    v.V.Parent,
 		Conjuncts: v.V.Conjuncts,
 	}
-	ctx.Unify(n, adt.Conjuncts)
+	n.CompleteArcs(ctx)
 
 	s = valueSorter{
 		a:    list,

--- a/pkg/list/sort.go
+++ b/pkg/list/sort.go
@@ -83,7 +83,7 @@ func (s *valueSorter) Less(i, j int) bool {
 
 	s.less.Finalize(s.ctx)
 	isLess := s.ctx.BoolValue(s.less)
-	if b := s.less.Err(s.ctx, adt.Finalized); b != nil && s.err == nil {
+	if b := s.less.Err(s.ctx); b != nil && s.err == nil {
 		s.err = b.Err
 		return true
 	}

--- a/pkg/path/pkg.go
+++ b/pkg/path/pkg.go
@@ -72,7 +72,7 @@ var (
 
 func newStr(s string) *adt.Vertex {
 	v := &adt.Vertex{}
-	v.SetValue(nil, adt.Finalized, &adt.String{Str: s})
+	v.SetValue(nil, &adt.String{Str: s})
 	return v
 }
 

--- a/tools/trim/trim.go
+++ b/tools/trim/trim.go
@@ -162,9 +162,9 @@ func isDominator(c adt.Conjunct) (ok, mayRemove bool) {
 	if !c.CloseInfo.IsInOneOf(dominatorNode) {
 		return false, false
 	}
-	switch c.Field().(type) {
-	case *adt.OptionalField: // bulk constraints handled elsewhere.
-		return true, false
+	switch f := c.Field().(type) {
+	case *adt.Field: // bulk constraints handled elsewhere.
+		return true, f.ArcType == adt.ArcMember
 	}
 	return true, true
 }


### PR DESCRIPTION
- internal/core/adt: merge OptionalField and Field types
- cue/ast: prepare for required fields
- internal/core/adt: implement required fields.
- internal/core/adt: allow required dynamic fields
- internal/core/adt: clone arcMap
- internal/core/adt: unexport Unify
- internal/core/adt: remove state arg from Err, SetValue, and UpdateValue
- internal/core/adt: unexport VertexStatus
- internal/core/adt: unexport more methods
- internal/core/adt: reorganize nodeContext fields
- internal/core/adt: hoist comprehension code
