### PR TITLE
internal/ci: remove workflow files pre generate

### DIFF
--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -38,14 +38,29 @@ _goos: string @tag(os,var=os)
 // See internal/ci/gen.go for details on how this step fits into the sequence
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
-command: gen: workflows: {
-	for _workflowName, _workflow in github.workflows {
-		let _filename = _workflowName + ".yml"
-		(_filename): file.Create & {
-			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
-			filename: path.Join([_dir, _filename], _goos)
-			let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
-			contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
+command: gen: {
+	_dir: path.FromSlash("../../.github/workflows", path.Unix)
+
+	workflows: {
+		remove: {
+			glob: file.Glob & {
+				glob: path.Join([_dir, "*.yml"], _goos)
+				files: [...string]
+			}
+			for _, _filename in glob.files {
+				"delete \(_filename)": file.RemoveAll & {
+					path: _filename
+				}
+			}
+		}
+		for _workflowName, _workflow in github.workflows {
+			let _filename = _workflowName + ".yml"
+			"generate \(_filename)": file.Create & {
+				$after: [ for v in remove {v}]
+				filename: path.Join([_dir, _filename], _goos)
+				let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
+				contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
+			}
 		}
 	}
 }


### PR DESCRIPTION
This ensures we can never have any stale .yml files lying around.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ib3a61d06cd5770294d8980de6de8ddaa7d037d48
