### PR TITLE
cue/load: avoid using ioutil.ReadDir to list directories

### DIFF
--- a/cue/load/search.go
+++ b/cue/load/search.go
@@ -17,7 +17,7 @@ package load
 import (
 	// TODO: remove this usage
 
-	"os"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -153,8 +153,8 @@ func (l *loader) matchPackagesInFS(pattern, pkgName string) *match {
 	// TODO(legacy): remove
 	pkgDir2 := filepath.Join(root, "pkg")
 
-	_ = c.fileSystem.walk(root, func(path string, fi os.FileInfo, err errors.Error) errors.Error {
-		if err != nil || !fi.IsDir() {
+	_ = c.fileSystem.walk(root, func(path string, entry fs.DirEntry, err errors.Error) errors.Error {
+		if err != nil || !entry.IsDir() {
 			return nil
 		}
 		if path == pkgDir || path == pkgDir2 {


### PR DESCRIPTION
Use os.ReadDir instead, which avoids having to call os.Lstat on each of
the files inside the directory.

This does mean a minor change to our internal API,
as we now obtain a list of fs.DirEntry rather than fs.FileInfo,
but that is fine as all the methods we need are Name and IsDir.

Also note that our overlay files currently implement fs.FileInfo,
so to avoid refactoring the overlay code, use fs.FileInfoToDirEntry.
Overlay files using fs.FileInfo don't incur the same syscall cost,
as they aren't real files on disk which we have to lstat.

This continues the work at https://cuelang.org/cl/538145,
which replaced filepath.Walk with filepath.WalkDir for the same reason.

To prove that this is a noticeable improvement in saved syscalls,
I used strace to count the number of lstat calls made to run the
package's tests before and after the change:

	$ go test -exec='strace -f --trace=newfstatat' | grep newfstat | wc -l
	687

	$ go test -exec='strace -f --trace=newfstatat' | grep newfstat | wc -l
	342

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I5df7e7c2d5821ea0fd246d91d9837c656e9b7123
