### PR TITLE
pkg/tool: small fixes to CUE docs

### DIFF
--- a/cmd/cue/cmd/help.go
+++ b/cmd/cue/cmd/help.go
@@ -480,15 +480,16 @@ cuelang.org/go/pkg/tool/tool.cue.
 		// otherwise depend on its output.
 		Tasks
 
+		// $usage summarizes how a command takes arguments.
 		//
 		// Example:
 		//     mycmd [-n] names
 		$usage?: string
 
-		// short is short description of what the command does.
+		// $short is short description of what the command does.
 		$short?: string
 
-		// long is a longer description that spans multiple lines and
+		// $long is a longer description that spans multiple lines and
 		// likely contain examples of usage of the command.
 		$long?: string
 	}
@@ -506,7 +507,7 @@ cuelang.org/go/pkg/tool/tool.cue.
 	Task: {
 		$type: "tool.Task" // legacy field 'kind' still supported for now.
 
-		// kind indicates the operation to run. It must be of the form
+		// $id indicates the operation to run. It must be of the form
 		// packagePath.Operation.
 		$id: =~#"\."#
 

--- a/pkg/tool/tool.cue
+++ b/pkg/tool/tool.cue
@@ -36,15 +36,16 @@ Command: {
 	// otherwise depend on its output.
 	Tasks
 
+	// $usage summarizes how a command takes arguments.
 	//
 	// Example:
 	//     mycmd [-n] names
 	$usage?: string
 
-	// short is short description of what the command does.
+	// $short is short description of what the command does.
 	$short?: string
 
-	// long is a longer description that spans multiple lines and
+	// $long is a longer description that spans multiple lines and
 	// likely contain examples of usage of the command.
 	$long?: string
 }
@@ -65,7 +66,7 @@ Name: =~#"^\PL([-](\PL|\PN))*$"#
 Task: {
 	$type: "tool.Task" // legacy field 'kind' still supported for now.
 
-	// kind indicates the operation to run. It must be of the form
+	// $id indicates the operation to run. It must be of the form
 	// packagePath.Operation.
 	$id: =~#"\."#
 


### PR DESCRIPTION
Noticed some weeks ago as I was reading the docs.
And the same changes to cmd/cue, where the CUE appears copy-pasted.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: Ie76af06c5aa854ae713cc700b1c0eaa3498bf6d8
