### PR TITLE
internal/pkg: move pkg/internal to internal/pkg

### DIFF
--- a/internal/pkg/builtin.go
+++ b/internal/pkg/builtin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package pkg
 
 import (
 	"encoding/json"

--- a/internal/pkg/context.go
+++ b/internal/pkg/context.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package pkg
 
 import (
 	"io"

--- a/internal/pkg/errors.go
+++ b/internal/pkg/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package pkg
 
 import (
 	"fmt"

--- a/internal/pkg/register.go
+++ b/internal/pkg/register.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package pkg
 
 import (
 	"cuelang.org/go/cue/errors"

--- a/internal/pkg/types.go
+++ b/internal/pkg/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package pkg
 
 import (
 	"cuelang.org/go/internal/core/adt"

--- a/pkg/crypto/ed25519/pkg.go
+++ b/pkg/crypto/ed25519/pkg.go
@@ -4,28 +4,28 @@ package ed25519
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("crypto/ed25519", pkg)
+	pkg.Register("crypto/ed25519", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "PublicKeySize",
 		Const: "32",
 	}, {
 		Name: "Valid",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			publicKey, message, signature := c.Bytes(0), c.Bytes(1), c.Bytes(2)
 			if c.Do() {
 				c.Ret, c.Err = Valid(publicKey, message, signature)

--- a/pkg/crypto/hmac/pkg.go
+++ b/pkg/crypto/hmac/pkg.go
@@ -4,17 +4,17 @@ package hmac
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("crypto/hmac", pkg)
+	pkg.Register("crypto/hmac", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "MD5",
 		Const: "\"MD5\"",
 	}, {
@@ -40,13 +40,13 @@ var pkg = &internal.Package{
 		Const: "\"SHA512_256\"",
 	}, {
 		Name: "Sign",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			hashName, key, data := c.String(0), c.Bytes(1), c.Bytes(2)
 			if c.Do() {
 				c.Ret, c.Err = Sign(hashName, key, data)

--- a/pkg/crypto/md5/pkg.go
+++ b/pkg/crypto/md5/pkg.go
@@ -4,17 +4,17 @@ package md5
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("crypto/md5", pkg)
+	pkg.Register("crypto/md5", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "Size",
 		Const: "16",
 	}, {
@@ -22,11 +22,11 @@ var pkg = &internal.Package{
 		Const: "64",
 	}, {
 		Name: "Sum",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum(data)

--- a/pkg/crypto/sha1/pkg.go
+++ b/pkg/crypto/sha1/pkg.go
@@ -4,17 +4,17 @@ package sha1
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("crypto/sha1", pkg)
+	pkg.Register("crypto/sha1", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "Size",
 		Const: "20",
 	}, {
@@ -22,11 +22,11 @@ var pkg = &internal.Package{
 		Const: "64",
 	}, {
 		Name: "Sum",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum(data)

--- a/pkg/crypto/sha256/pkg.go
+++ b/pkg/crypto/sha256/pkg.go
@@ -4,17 +4,17 @@ package sha256
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("crypto/sha256", pkg)
+	pkg.Register("crypto/sha256", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "Size",
 		Const: "32",
 	}, {
@@ -25,11 +25,11 @@ var pkg = &internal.Package{
 		Const: "64",
 	}, {
 		Name: "Sum256",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum256(data)
@@ -37,11 +37,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sum224",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum224(data)

--- a/pkg/crypto/sha512/pkg.go
+++ b/pkg/crypto/sha512/pkg.go
@@ -4,17 +4,17 @@ package sha512
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("crypto/sha512", pkg)
+	pkg.Register("crypto/sha512", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "Size",
 		Const: "64",
 	}, {
@@ -31,11 +31,11 @@ var pkg = &internal.Package{
 		Const: "128",
 	}, {
 		Name: "Sum512",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum512(data)
@@ -43,11 +43,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sum384",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum384(data)
@@ -55,11 +55,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sum512_224",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum512_224(data)
@@ -67,11 +67,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sum512_256",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Sum512_256(data)

--- a/pkg/encoding/base64/pkg.go
+++ b/pkg/encoding/base64/pkg.go
@@ -4,24 +4,24 @@ package base64
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("encoding/base64", pkg)
+	pkg.Register("encoding/base64", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "EncodedLen",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			encoding, n := c.Value(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = EncodedLen(encoding, n)
@@ -29,12 +29,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "DecodedLen",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			encoding, x := c.Value(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = DecodedLen(encoding, x)
@@ -42,12 +42,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Encode",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			encoding, src := c.Value(0), c.Bytes(1)
 			if c.Do() {
 				c.Ret, c.Err = Encode(encoding, src)
@@ -55,12 +55,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Decode",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			encoding, s := c.Value(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = Decode(encoding, s)

--- a/pkg/encoding/csv/pkg.go
+++ b/pkg/encoding/csv/pkg.go
@@ -4,23 +4,23 @@ package csv
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("encoding/csv", pkg)
+	pkg.Register("encoding/csv", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Encode",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = Encode(x)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Decode",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			r := c.Reader(0)
 			if c.Do() {
 				c.Ret, c.Err = Decode(r)

--- a/pkg/encoding/hex/pkg.go
+++ b/pkg/encoding/hex/pkg.go
@@ -4,23 +4,23 @@ package hex
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("encoding/hex", pkg)
+	pkg.Register("encoding/hex", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "EncodedLen",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			n := c.Int(0)
 			if c.Do() {
 				c.Ret = EncodedLen(n)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "DecodedLen",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Int(0)
 			if c.Do() {
 				c.Ret = DecodedLen(x)
@@ -40,11 +40,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Decode",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Decode(s)
@@ -52,11 +52,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Dump",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Dump(data)
@@ -64,11 +64,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Encode",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			src := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Encode(src)

--- a/pkg/encoding/json/pkg.go
+++ b/pkg/encoding/json/pkg.go
@@ -4,23 +4,23 @@ package json
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("encoding/json", pkg)
+	pkg.Register("encoding/json", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Valid",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret = Valid(data)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Compact",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			src := c.Bytes(0)
 			if c.Do() {
 				c.Ret, c.Err = Compact(src)
@@ -40,13 +40,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Indent",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			src, prefix, indent := c.Bytes(0), c.String(1), c.String(2)
 			if c.Do() {
 				c.Ret, c.Err = Indent(src, prefix, indent)
@@ -54,11 +54,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "HTMLEscape",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			src := c.Bytes(0)
 			if c.Do() {
 				c.Ret = HTMLEscape(src)
@@ -66,11 +66,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Marshal",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			v := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = Marshal(v)
@@ -78,11 +78,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MarshalStream",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			v := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = MarshalStream(v)
@@ -90,11 +90,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "UnmarshalStream",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.TopKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret, c.Err = UnmarshalStream(data)
@@ -102,11 +102,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Unmarshal",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.TopKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b := c.Bytes(0)
 			if c.Do() {
 				c.Ret, c.Err = Unmarshal(b)
@@ -114,12 +114,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Validate",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b, v := c.Bytes(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = Validate(b, v)

--- a/pkg/encoding/yaml/manual.go
+++ b/pkg/encoding/yaml/manual.go
@@ -22,8 +22,8 @@ import (
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/errors"
 	cueyaml "cuelang.org/go/internal/encoding/yaml"
+	"cuelang.org/go/internal/pkg"
 	"cuelang.org/go/internal/third_party/yaml"
-	"cuelang.org/go/pkg/internal"
 )
 
 // Marshal returns the YAML encoding of v.
@@ -126,7 +126,7 @@ func Validate(b []byte, v cue.Value) (bool, error) {
 		}
 		if err := x.Validate(cue.Concrete(true)); err != nil {
 			// Strip error codes: incomplete errors are terminal in this case.
-			var b internal.Bottomer
+			var b pkg.Bottomer
 			if errors.As(err, &b) {
 				err = b.Bottom().Err
 			}

--- a/pkg/encoding/yaml/pkg.go
+++ b/pkg/encoding/yaml/pkg.go
@@ -4,23 +4,23 @@ package yaml
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("encoding/yaml", pkg)
+	pkg.Register("encoding/yaml", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Marshal",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			v := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = Marshal(v)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MarshalStream",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			v := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = MarshalStream(v)
@@ -40,11 +40,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Unmarshal",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.TopKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret, c.Err = Unmarshal(data)
@@ -52,11 +52,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "UnmarshalStream",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.TopKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Bytes(0)
 			if c.Do() {
 				c.Ret, c.Err = UnmarshalStream(data)
@@ -64,12 +64,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Validate",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b, v := c.Bytes(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = Validate(b, v)
@@ -77,12 +77,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ValidatePartial",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b, v := c.Bytes(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = ValidatePartial(b, v)

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -77,11 +77,11 @@ package {{.GoPkg}}
 {{if .CUEPkg -}}
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register({{printf "%q" .CUEPkg}}, pkg)
+	pkg.Register({{printf "%q" .CUEPkg}}, p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
@@ -157,7 +157,7 @@ func generate(cuePkgPath string) error {
 	}
 
 	if !skipRegister {
-		fmt.Fprintf(g.w, "var pkg = &internal.Package{\nNative: []*internal.Builtin{")
+		fmt.Fprintf(g.w, "var p = &pkg.Package{\nNative: []*pkg.Builtin{")
 		g.first = true
 		for _, filename := range pkg.GoFiles {
 			if filename == genFile {
@@ -334,7 +334,7 @@ func (g *generator) genFunc(x *ast.FuncDecl) {
 		}
 	}
 
-	fmt.Fprintf(g.w, "Params: []internal.Param{\n")
+	fmt.Fprintf(g.w, "Params: []pkg.Param{\n")
 	for _, k := range kind {
 		fmt.Fprintf(g.w, "{Kind: %s},\n", k)
 	}
@@ -350,7 +350,7 @@ func (g *generator) genFunc(x *ast.FuncDecl) {
 		init = fmt.Sprintf("%s := %s", argList, valList)
 	}
 
-	fmt.Fprintf(g.w, "Func: func(c *internal.CallCtxt) {")
+	fmt.Fprintf(g.w, "Func: func(c *pkg.CallCtxt) {")
 	defer fmt.Fprintln(g.w, "},")
 	fmt.Fprintln(g.w)
 	if init != "" {
@@ -382,9 +382,9 @@ func (g *generator) goKind(expr ast.Expr) string {
 		return "error"
 	case "internal.Decimal":
 		return "decimal"
-	case "internal.List":
+	case "pkg.List":
 		return "cueList"
-	case "internal.Struct":
+	case "pkg.Struct":
 		return "struct"
 	case "[]*internal.Decimal":
 		return "decimalList"

--- a/pkg/html/pkg.go
+++ b/pkg/html/pkg.go
@@ -4,23 +4,23 @@ package html
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("html", pkg)
+	pkg.Register("html", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Escape",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = Escape(s)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Unescape",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = Unescape(s)

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -23,7 +23,7 @@ import (
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/token"
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 // Drop reports the suffix of list x after the first n elements,
@@ -216,7 +216,7 @@ func Slice(x []cue.Value, i, j int) ([]cue.Value, error) {
 }
 
 // MinItems reports whether a has at least n items.
-func MinItems(list internal.List, n int) (bool, error) {
+func MinItems(list pkg.List, n int) (bool, error) {
 	count := len(list.Elems())
 	if count >= n {
 		return true, nil
@@ -225,17 +225,17 @@ func MinItems(list internal.List, n int) (bool, error) {
 	if list.IsOpen() {
 		code = adt.IncompleteError
 	}
-	return false, internal.ValidationError{B: &adt.Bottom{
+	return false, pkg.ValidationError{B: &adt.Bottom{
 		Code: code,
 		Err:  errors.Newf(token.NoPos, "len(list) < MinItems(%[2]d) (%[1]d < %[2]d)", count, n),
 	}}
 }
 
 // MaxItems reports whether a has at most n items.
-func MaxItems(list internal.List, n int) (bool, error) {
+func MaxItems(list pkg.List, n int) (bool, error) {
 	count := len(list.Elems())
 	if count > n {
-		return false, internal.ValidationError{B: &adt.Bottom{
+		return false, pkg.ValidationError{B: &adt.Bottom{
 			Code: adt.EvalError,
 			Err:  errors.Newf(token.NoPos, "len(list) > MaxItems(%[2]d) (%[1]d > %[2]d)", count, n),
 		}}

--- a/pkg/list/pkg.go
+++ b/pkg/list/pkg.go
@@ -4,24 +4,24 @@ package list
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("list", pkg)
+	pkg.Register("list", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Drop",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, n := c.List(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = Drop(x, n)
@@ -29,12 +29,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FlattenN",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			xs, depth := c.Value(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = FlattenN(xs, depth)
@@ -42,12 +42,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Repeat",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, count := c.List(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = Repeat(x, count)
@@ -55,11 +55,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Concat",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a := c.List(0)
 			if c.Do() {
 				c.Ret, c.Err = Concat(a)
@@ -67,12 +67,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Take",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, n := c.List(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = Take(x, n)
@@ -80,13 +80,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Slice",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, i, j := c.List(0), c.Int(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = Slice(x, i, j)
@@ -94,12 +94,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MinItems",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			list, n := c.CueList(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = MinItems(list, n)
@@ -107,12 +107,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MaxItems",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			list, n := c.CueList(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = MaxItems(list, n)
@@ -120,11 +120,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "UniqueItems",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a := c.List(0)
 			if c.Do() {
 				c.Ret = UniqueItems(a)
@@ -132,12 +132,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Contains",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a, v := c.List(0), c.Value(1)
 			if c.Do() {
 				c.Ret = Contains(a, v)
@@ -145,11 +145,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Avg",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			xs := c.DecimalList(0)
 			if c.Do() {
 				c.Ret, c.Err = Avg(xs)
@@ -157,11 +157,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Max",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			xs := c.DecimalList(0)
 			if c.Do() {
 				c.Ret, c.Err = Max(xs)
@@ -169,11 +169,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Min",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			xs := c.DecimalList(0)
 			if c.Do() {
 				c.Ret, c.Err = Min(xs)
@@ -181,11 +181,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Product",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			xs := c.DecimalList(0)
 			if c.Do() {
 				c.Ret, c.Err = Product(xs)
@@ -193,13 +193,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Range",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			start, limit, step := c.Decimal(0), c.Decimal(1), c.Decimal(2)
 			if c.Do() {
 				c.Ret, c.Err = Range(start, limit, step)
@@ -207,11 +207,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sum",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			xs := c.DecimalList(0)
 			if c.Do() {
 				c.Ret, c.Err = Sum(xs)
@@ -219,12 +219,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sort",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			list, cmp := c.List(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = Sort(list, cmp)
@@ -232,12 +232,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SortStable",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			list, cmp := c.List(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = SortStable(list, cmp)
@@ -245,11 +245,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SortStrings",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a := c.StringList(0)
 			if c.Do() {
 				c.Ret = SortStrings(a)
@@ -257,12 +257,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IsSorted",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			list, cmp := c.List(0), c.Value(1)
 			if c.Do() {
 				c.Ret = IsSorted(list, cmp)
@@ -270,11 +270,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IsSortedStrings",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a := c.StringList(0)
 			if c.Do() {
 				c.Ret = IsSortedStrings(a)

--- a/pkg/math/bits/pkg.go
+++ b/pkg/math/bits/pkg.go
@@ -4,24 +4,24 @@ package bits
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("math/bits", pkg)
+	pkg.Register("math/bits", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Lsh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, n := c.BigInt(0), c.Uint(1)
 			if c.Do() {
 				c.Ret = Lsh(x, n)
@@ -29,12 +29,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Rsh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, n := c.BigInt(0), c.Uint(1)
 			if c.Do() {
 				c.Ret = Rsh(x, n)
@@ -42,12 +42,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "At",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, i := c.BigInt(0), c.Uint(1)
 			if c.Do() {
 				c.Ret, c.Err = At(x, i)
@@ -55,13 +55,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Set",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, i, bit := c.BigInt(0), c.Int(1), c.Uint(2)
 			if c.Do() {
 				c.Ret = Set(x, i, bit)
@@ -69,12 +69,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "And",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a, b := c.BigInt(0), c.BigInt(1)
 			if c.Do() {
 				c.Ret = And(a, b)
@@ -82,12 +82,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Or",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a, b := c.BigInt(0), c.BigInt(1)
 			if c.Do() {
 				c.Ret = Or(a, b)
@@ -95,12 +95,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Xor",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a, b := c.BigInt(0), c.BigInt(1)
 			if c.Do() {
 				c.Ret = Xor(a, b)
@@ -108,12 +108,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Clear",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a, b := c.BigInt(0), c.BigInt(1)
 			if c.Do() {
 				c.Ret = Clear(a, b)
@@ -121,11 +121,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "OnesCount",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.BigInt(0)
 			if c.Do() {
 				c.Ret = OnesCount(x)
@@ -133,11 +133,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Len",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.BigInt(0)
 			if c.Do() {
 				c.Ret = Len(x)

--- a/pkg/math/pkg.go
+++ b/pkg/math/pkg.go
@@ -4,17 +4,17 @@ package math
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("math", pkg)
+	pkg.Register("math", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "MaxExp",
 		Const: "2147483647",
 	}, {
@@ -52,12 +52,12 @@ var pkg = &internal.Package{
 		Const: "1",
 	}, {
 		Name: "Jacobi",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.BigInt(0), c.BigInt(1)
 			if c.Do() {
 				c.Ret = Jacobi(x, y)
@@ -68,11 +68,11 @@ var pkg = &internal.Package{
 		Const: "62",
 	}, {
 		Name: "Floor",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Floor(x)
@@ -80,11 +80,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Ceil",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Ceil(x)
@@ -92,11 +92,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Trunc",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Trunc(x)
@@ -104,11 +104,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Round",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Round(x)
@@ -116,11 +116,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "RoundToEven",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = RoundToEven(x)
@@ -128,12 +128,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MultipleOf",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.Decimal(0), c.Decimal(1)
 			if c.Do() {
 				c.Ret, c.Err = MultipleOf(x, y)
@@ -141,11 +141,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Abs",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Abs(x)
@@ -153,11 +153,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Acosh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Acosh(x)
@@ -165,11 +165,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Asin",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Asin(x)
@@ -177,11 +177,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Acos",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Acos(x)
@@ -189,11 +189,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Asinh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Asinh(x)
@@ -201,11 +201,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Atan",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Atan(x)
@@ -213,12 +213,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Atan2",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			y, x := c.Float64(0), c.Float64(1)
 			if c.Do() {
 				c.Ret = Atan2(y, x)
@@ -226,11 +226,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Atanh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Atanh(x)
@@ -238,11 +238,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Cbrt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Cbrt(x)
@@ -283,12 +283,12 @@ var pkg = &internal.Package{
 		Const: "0.43429448190325182765112891891660508229439700580366656611445378",
 	}, {
 		Name: "Copysign",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.Decimal(0), c.Decimal(1)
 			if c.Do() {
 				c.Ret = Copysign(x, y)
@@ -296,12 +296,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Dim",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.Decimal(0), c.Decimal(1)
 			if c.Do() {
 				c.Ret, c.Err = Dim(x, y)
@@ -309,11 +309,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Erf",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Erf(x)
@@ -321,11 +321,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Erfc",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Erfc(x)
@@ -333,11 +333,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Erfinv",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Erfinv(x)
@@ -345,11 +345,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Erfcinv",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Erfcinv(x)
@@ -357,11 +357,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Exp",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Exp(x)
@@ -369,11 +369,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Exp2",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Exp2(x)
@@ -381,11 +381,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Expm1",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Expm1(x)
@@ -393,11 +393,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Gamma",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Gamma(x)
@@ -405,12 +405,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Hypot",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			p, q := c.Float64(0), c.Float64(1)
 			if c.Do() {
 				c.Ret = Hypot(p, q)
@@ -418,11 +418,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "J0",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = J0(x)
@@ -430,11 +430,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Y0",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Y0(x)
@@ -442,11 +442,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "J1",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = J1(x)
@@ -454,11 +454,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Y1",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Y1(x)
@@ -466,12 +466,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Jn",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			n, x := c.Int(0), c.Float64(1)
 			if c.Do() {
 				c.Ret = Jn(n, x)
@@ -479,12 +479,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Yn",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			n, x := c.Int(0), c.Float64(1)
 			if c.Do() {
 				c.Ret = Yn(n, x)
@@ -492,12 +492,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Ldexp",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			frac, exp := c.Float64(0), c.Int(1)
 			if c.Do() {
 				c.Ret = Ldexp(frac, exp)
@@ -505,11 +505,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Log",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Log(x)
@@ -517,11 +517,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Log10",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Log10(x)
@@ -529,11 +529,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Log2",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret, c.Err = Log2(x)
@@ -541,11 +541,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Log1p",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Log1p(x)
@@ -553,11 +553,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Logb",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Logb(x)
@@ -565,11 +565,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Ilogb",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Ilogb(x)
@@ -577,12 +577,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Mod",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.Float64(0), c.Float64(1)
 			if c.Do() {
 				c.Ret = Mod(x, y)
@@ -590,12 +590,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Pow",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.Decimal(0), c.Decimal(1)
 			if c.Do() {
 				c.Ret, c.Err = Pow(x, y)
@@ -603,11 +603,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Pow10",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			n := c.Int32(0)
 			if c.Do() {
 				c.Ret = Pow10(n)
@@ -615,12 +615,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Remainder",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x, y := c.Float64(0), c.Float64(1)
 			if c.Do() {
 				c.Ret = Remainder(x, y)
@@ -628,11 +628,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Signbit",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Decimal(0)
 			if c.Do() {
 				c.Ret = Signbit(x)
@@ -640,11 +640,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Cos",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Cos(x)
@@ -652,11 +652,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sin",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Sin(x)
@@ -664,11 +664,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sinh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Sinh(x)
@@ -676,11 +676,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Cosh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Cosh(x)
@@ -688,11 +688,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Sqrt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Sqrt(x)
@@ -700,11 +700,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Tan",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Tan(x)
@@ -712,11 +712,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Tanh",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.Float64(0)
 			if c.Do() {
 				c.Ret = Tanh(x)

--- a/pkg/net/pkg.go
+++ b/pkg/net/pkg.go
@@ -4,23 +4,23 @@ package net
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("net", pkg)
+	pkg.Register("net", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "SplitHostPort",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = SplitHostPort(s)
@@ -28,12 +28,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "JoinHostPort",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			host, port := c.Value(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = JoinHostPort(host, port)
@@ -41,11 +41,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FQDN",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = FQDN(s)
@@ -59,11 +59,11 @@ var pkg = &internal.Package{
 		Const: "16",
 	}, {
 		Name: "ParseIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = ParseIP(s)
@@ -71,11 +71,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IPv4",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = IPv4(ip)
@@ -83,11 +83,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = IP(ip)
@@ -95,11 +95,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IPCIDR",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = IPCIDR(ip)
@@ -107,11 +107,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "LoopbackIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = LoopbackIP(ip)
@@ -119,11 +119,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MulticastIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = MulticastIP(ip)
@@ -131,11 +131,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "InterfaceLocalMulticastIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = InterfaceLocalMulticastIP(ip)
@@ -143,11 +143,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "LinkLocalMulticastIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = LinkLocalMulticastIP(ip)
@@ -155,11 +155,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "LinkLocalUnicastIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = LinkLocalUnicastIP(ip)
@@ -167,11 +167,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "GlobalUnicastIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = GlobalUnicastIP(ip)
@@ -179,11 +179,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "UnspecifiedIP",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret = UnspecifiedIP(ip)
@@ -191,11 +191,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToIP4",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = ToIP4(ip)
@@ -203,11 +203,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToIP16",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = ToIP16(ip)
@@ -215,11 +215,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IPString",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			ip := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = IPString(ip)

--- a/pkg/path/pkg.go
+++ b/pkg/path/pkg.go
@@ -16,11 +16,11 @@ package path
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("path", pkg)
+	pkg.Register("path", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
@@ -76,20 +76,20 @@ func newStr(s string) *adt.Vertex {
 	return v
 }
 
-var pkg = &internal.Package{
+var p = &pkg.Package{
 	CUE: `{
 		Unix:    "unix"
 		Windows: "windows"
 		Plan9:   "plan9"
 	}`,
-	Native: []*internal.Builtin{{
+	Native: []*pkg.Builtin{{
 		Name: "Split",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Split(path, OS(os))
@@ -97,12 +97,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SplitList",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: osRequired},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = SplitList(path, OS(os))
@@ -110,12 +110,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Join",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			list, os := c.StringList(0), c.String(1)
 			if c.Do() {
 				c.Ret = Join(list, OS(os))
@@ -123,12 +123,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Match",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, name, os := c.String(0), c.String(1), c.String(2)
 			if c.Do() {
 				c.Ret, c.Err = Match(pattern, name, OS(os))
@@ -136,12 +136,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Clean",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Clean(path, OS(os))
@@ -149,12 +149,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToSlash",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: osRequired},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = ToSlash(path, OS(os))
@@ -162,12 +162,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FromSlash",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: osRequired},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = FromSlash(path, OS(os))
@@ -175,12 +175,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Ext",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Ext(path, OS(os))
@@ -188,13 +188,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Resolve",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			dir, sub, os := c.String(0), c.String(1), c.String(2)
 			if c.Do() {
 				c.Ret = Resolve(dir, sub, OS(os))
@@ -202,13 +202,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Rel",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			base, target, os := c.String(0), c.String(1), c.String(2)
 			if c.Do() {
 				c.Ret, c.Err = Rel(base, target, OS(os))
@@ -216,12 +216,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Base",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Base(path, OS(os))
@@ -229,12 +229,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Dir",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Dir(path, OS(os))
@@ -242,12 +242,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IsAbs",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = IsAbs(path, OS(os))
@@ -255,12 +255,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "VolumeName",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: windowsDefault},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			path, os := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = VolumeName(path, OS(os))

--- a/pkg/regexp/pkg.go
+++ b/pkg/regexp/pkg.go
@@ -4,24 +4,24 @@ package regexp
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("regexp", pkg)
+	pkg.Register("regexp", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Find",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = Find(pattern, s)
@@ -29,13 +29,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FindAll",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s, n := c.String(0), c.String(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = FindAll(pattern, s, n)
@@ -43,13 +43,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FindAllNamedSubmatch",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s, n := c.String(0), c.String(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = FindAllNamedSubmatch(pattern, s, n)
@@ -57,13 +57,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FindAllSubmatch",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s, n := c.String(0), c.String(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = FindAllSubmatch(pattern, s, n)
@@ -71,12 +71,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FindNamedSubmatch",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StructKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = FindNamedSubmatch(pattern, s)
@@ -84,12 +84,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FindSubmatch",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = FindSubmatch(pattern, s)
@@ -97,13 +97,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ReplaceAll",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, src, repl := c.String(0), c.String(1), c.String(2)
 			if c.Do() {
 				c.Ret, c.Err = ReplaceAll(pattern, src, repl)
@@ -111,13 +111,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ReplaceAllLiteral",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, src, repl := c.String(0), c.String(1), c.String(2)
 			if c.Do() {
 				c.Ret, c.Err = ReplaceAllLiteral(pattern, src, repl)
@@ -125,11 +125,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Valid",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Valid(pattern)
@@ -137,12 +137,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Match",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			pattern, s := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = Match(pattern, s)
@@ -150,11 +150,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "QuoteMeta",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = QuoteMeta(s)

--- a/pkg/strconv/pkg.go
+++ b/pkg/strconv/pkg.go
@@ -4,23 +4,23 @@ package strconv
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("strconv", pkg)
+	pkg.Register("strconv", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Unquote",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Unquote(s)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ParseBool",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			str := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = ParseBool(str)
@@ -40,11 +40,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FormatBool",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BoolKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b := c.Bool(0)
 			if c.Do() {
 				c.Ret = FormatBool(b)
@@ -52,12 +52,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ParseComplex",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.TopKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, bitSize := c.String(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = ParseComplex(s, bitSize)
@@ -65,12 +65,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ParseFloat",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.NumKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, bitSize := c.String(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = ParseFloat(s, bitSize)
@@ -81,13 +81,13 @@ var pkg = &internal.Package{
 		Const: "64",
 	}, {
 		Name: "ParseUint",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, base, bitSize := c.String(0), c.Int(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = ParseUint(s, base, bitSize)
@@ -95,13 +95,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ParseInt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, base, bitSize := c.String(0), c.Int(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = ParseInt(s, base, bitSize)
@@ -109,11 +109,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Atoi",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Atoi(s)
@@ -121,14 +121,14 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FormatFloat",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.NumKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			f, fmt, prec, bitSize := c.Float64(0), c.Byte(1), c.Int(2), c.Int(3)
 			if c.Do() {
 				c.Ret = FormatFloat(f, fmt, prec, bitSize)
@@ -136,12 +136,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FormatUint",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			i, base := c.BigInt(0), c.Int(1)
 			if c.Do() {
 				c.Ret = FormatUint(i, base)
@@ -149,12 +149,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FormatInt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			i, base := c.BigInt(0), c.Int(1)
 			if c.Do() {
 				c.Ret = FormatInt(i, base)
@@ -162,11 +162,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Quote",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = Quote(s)
@@ -174,11 +174,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "QuoteToASCII",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = QuoteToASCII(s)
@@ -186,11 +186,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "QuoteToGraphic",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = QuoteToGraphic(s)
@@ -198,11 +198,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "QuoteRune",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			r := c.Rune(0)
 			if c.Do() {
 				c.Ret = QuoteRune(r)
@@ -210,11 +210,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "QuoteRuneToASCII",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			r := c.Rune(0)
 			if c.Do() {
 				c.Ret = QuoteRuneToASCII(r)
@@ -222,11 +222,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "QuoteRuneToGraphic",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			r := c.Rune(0)
 			if c.Do() {
 				c.Ret = QuoteRuneToGraphic(r)
@@ -234,11 +234,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IsPrint",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			r := c.Rune(0)
 			if c.Do() {
 				c.Ret = IsPrint(r)
@@ -246,11 +246,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IsGraphic",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			r := c.Rune(0)
 			if c.Do() {
 				c.Ret = IsGraphic(r)

--- a/pkg/strings/pkg.go
+++ b/pkg/strings/pkg.go
@@ -4,24 +4,24 @@ package strings
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("strings", pkg)
+	pkg.Register("strings", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "ByteAt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b, i := c.Bytes(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = ByteAt(b, i)
@@ -29,13 +29,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ByteSlice",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.BytesKind | adt.StringKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BytesKind | adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			b, start, end := c.Bytes(0), c.Int(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = ByteSlice(b, start, end)
@@ -43,11 +43,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Runes",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = Runes(s)
@@ -55,12 +55,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MinRunes",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, min := c.String(0), c.Int(1)
 			if c.Do() {
 				c.Ret = MinRunes(s, min)
@@ -68,12 +68,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MaxRunes",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, max := c.String(0), c.Int(1)
 			if c.Do() {
 				c.Ret = MaxRunes(s, max)
@@ -81,11 +81,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToTitle",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = ToTitle(s)
@@ -93,11 +93,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToCamel",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = ToCamel(s)
@@ -105,13 +105,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SliceRunes",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, start, end := c.String(0), c.Int(1), c.Int(2)
 			if c.Do() {
 				c.Ret, c.Err = SliceRunes(s, start, end)
@@ -119,12 +119,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Compare",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			a, b := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Compare(a, b)
@@ -132,12 +132,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Count",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, substr := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Count(s, substr)
@@ -145,12 +145,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Contains",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, substr := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Contains(s, substr)
@@ -158,12 +158,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ContainsAny",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, chars := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = ContainsAny(s, chars)
@@ -171,12 +171,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "LastIndex",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, substr := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = LastIndex(s, substr)
@@ -184,12 +184,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "IndexAny",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, chars := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = IndexAny(s, chars)
@@ -197,12 +197,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "LastIndexAny",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, chars := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = LastIndexAny(s, chars)
@@ -210,13 +210,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SplitN",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, sep, n := c.String(0), c.String(1), c.Int(2)
 			if c.Do() {
 				c.Ret = SplitN(s, sep, n)
@@ -224,13 +224,13 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SplitAfterN",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, sep, n := c.String(0), c.String(1), c.Int(2)
 			if c.Do() {
 				c.Ret = SplitAfterN(s, sep, n)
@@ -238,12 +238,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Split",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, sep := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Split(s, sep)
@@ -251,12 +251,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SplitAfter",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, sep := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = SplitAfter(s, sep)
@@ -264,11 +264,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Fields",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.ListKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = Fields(s)
@@ -276,12 +276,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Join",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.ListKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			elems, sep := c.StringList(0), c.String(1)
 			if c.Do() {
 				c.Ret = Join(elems, sep)
@@ -289,12 +289,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "HasPrefix",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, prefix := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = HasPrefix(s, prefix)
@@ -302,12 +302,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "HasSuffix",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, suffix := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = HasSuffix(s, suffix)
@@ -315,12 +315,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Repeat",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, count := c.String(0), c.Int(1)
 			if c.Do() {
 				c.Ret = Repeat(s, count)
@@ -328,11 +328,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToUpper",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = ToUpper(s)
@@ -340,11 +340,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToLower",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = ToLower(s)
@@ -352,12 +352,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Trim",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, cutset := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Trim(s, cutset)
@@ -365,12 +365,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "TrimLeft",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, cutset := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = TrimLeft(s, cutset)
@@ -378,12 +378,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "TrimRight",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, cutset := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = TrimRight(s, cutset)
@@ -391,11 +391,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "TrimSpace",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = TrimSpace(s)
@@ -403,12 +403,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "TrimPrefix",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, prefix := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = TrimPrefix(s, prefix)
@@ -416,12 +416,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "TrimSuffix",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, suffix := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = TrimSuffix(s, suffix)
@@ -429,14 +429,14 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Replace",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, old, new, n := c.String(0), c.String(1), c.String(2), c.Int(3)
 			if c.Do() {
 				c.Ret = Replace(s, old, new, n)
@@ -444,12 +444,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Index",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s, substr := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret = Index(s, substr)

--- a/pkg/struct/pkg.go
+++ b/pkg/struct/pkg.go
@@ -4,24 +4,24 @@ package structs
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("struct", pkg)
+	pkg.Register("struct", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "MinFields",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StructKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			object, n := c.Struct(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = MinFields(object, n)
@@ -29,12 +29,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MaxFields",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StructKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			object, n := c.Struct(0), c.Int(1)
 			if c.Do() {
 				c.Ret, c.Err = MaxFields(object, n)

--- a/pkg/struct/struct.go
+++ b/pkg/struct/struct.go
@@ -19,7 +19,7 @@ import (
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/token"
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 // MinFields validates the minimum number of fields that are part of a struct.
@@ -27,14 +27,14 @@ import (
 //
 // Only fields that are part of the data model count. This excludes hidden
 // fields, optional fields, and definitions.
-func MinFields(object internal.Struct, n int) (bool, error) {
+func MinFields(object pkg.Struct, n int) (bool, error) {
 	count := object.Len()
 	code := adt.EvalError
 	if object.IsOpen() {
 		code = adt.IncompleteError
 	}
 	if count < n {
-		return false, internal.ValidationError{B: &adt.Bottom{
+		return false, pkg.ValidationError{B: &adt.Bottom{
 			Code: code,
 			Err:  errors.Newf(token.NoPos, "len(fields) < MinFields(%[2]d) (%[1]d < %[2]d)", count, n),
 		}}
@@ -47,10 +47,10 @@ func MinFields(object internal.Struct, n int) (bool, error) {
 //
 // Only fields that are part of the data model count. This excludes hidden
 // fields, optional fields, and definitions.
-func MaxFields(object internal.Struct, n int) (bool, error) {
+func MaxFields(object pkg.Struct, n int) (bool, error) {
 	count := object.Len()
 	if count > n {
-		return false, internal.ValidationError{B: &adt.Bottom{
+		return false, pkg.ValidationError{B: &adt.Bottom{
 			Code: adt.EvalError,
 			Err:  errors.Newf(token.NoPos, "len(fields) > MaxFields(%[2]d) (%[1]d > %[2]d)", count, n),
 		}}

--- a/pkg/text/tabwriter/pkg.go
+++ b/pkg/text/tabwriter/pkg.go
@@ -4,23 +4,23 @@ package tabwriter
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("text/tabwriter", pkg)
+	pkg.Register("text/tabwriter", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Write",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			data := c.Value(0)
 			if c.Do() {
 				c.Ret, c.Err = Write(data)

--- a/pkg/text/template/pkg.go
+++ b/pkg/text/template/pkg.go
@@ -4,24 +4,24 @@ package template
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("text/template", pkg)
+	pkg.Register("text/template", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Execute",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.TopKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			templ, data := c.String(0), c.Value(1)
 			if c.Do() {
 				c.Ret, c.Err = Execute(templ, data)
@@ -29,11 +29,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "HTMLEscape",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = HTMLEscape(s)
@@ -41,11 +41,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "JSEscape",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = JSEscape(s)

--- a/pkg/time/pkg.go
+++ b/pkg/time/pkg.go
@@ -4,17 +4,17 @@ package time
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("time", pkg)
+	pkg.Register("time", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name:  "Nanosecond",
 		Const: "1",
 	}, {
@@ -34,11 +34,11 @@ var pkg = &internal.Package{
 		Const: "3600000000000",
 	}, {
 		Name: "Duration",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Duration(s)
@@ -46,11 +46,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FormatDuration",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			d := c.Int64(0)
 			if c.Do() {
 				c.Ret = FormatDuration(d)
@@ -58,11 +58,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ParseDuration",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = ParseDuration(s)
@@ -166,11 +166,11 @@ var pkg = &internal.Package{
 		Const: "6",
 	}, {
 		Name: "Time",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Time(s)
@@ -178,12 +178,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Format",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BoolKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			value, layout := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = Format(value, layout)
@@ -191,12 +191,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FormatString",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			layout, value := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = FormatString(layout, value)
@@ -204,12 +204,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Parse",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			layout, value := c.String(0), c.String(1)
 			if c.Do() {
 				c.Ret, c.Err = Parse(layout, value)
@@ -217,12 +217,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Unix",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			sec, nsec := c.Int64(0), c.Int64(1)
 			if c.Do() {
 				c.Ret = Unix(sec, nsec)
@@ -230,11 +230,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Split",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.TopKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			t := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Split(t)

--- a/pkg/tool/cli/pkg.go
+++ b/pkg/tool/cli/pkg.go
@@ -33,17 +33,17 @@ package cli
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("tool/cli", pkg)
+	pkg.Register("tool/cli", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{},
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{},
 	CUE: `{
 	Print: {
 		$id:  *"tool/cli.Print" | "print"

--- a/pkg/tool/exec/pkg.go
+++ b/pkg/tool/exec/pkg.go
@@ -43,17 +43,17 @@ package exec
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("tool/exec", pkg)
+	pkg.Register("tool/exec", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{},
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{},
 	CUE: `{
 	Run: {
 		$id:  *"tool/exec.Run" | "exec"

--- a/pkg/tool/file/pkg.go
+++ b/pkg/tool/file/pkg.go
@@ -128,17 +128,17 @@ package file
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("tool/file", pkg)
+	pkg.Register("tool/file", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{},
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{},
 	CUE: `{
 	Read: {
 		$id:      "tool/file.Read"

--- a/pkg/tool/http/pkg.go
+++ b/pkg/tool/http/pkg.go
@@ -53,17 +53,17 @@ package http
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("tool/http", pkg)
+	pkg.Register("tool/http", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{},
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{},
 	CUE: `{
 	Get: Do & {
 		method: "GET"

--- a/pkg/tool/os/pkg.go
+++ b/pkg/tool/os/pkg.go
@@ -48,17 +48,17 @@ package os
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("tool/os", pkg)
+	pkg.Register("tool/os", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{},
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{},
 	CUE: `{
 	Value: bool | number | *string | null
 	Name:  !="" & !~"^[$]"

--- a/pkg/uuid/pkg.go
+++ b/pkg/uuid/pkg.go
@@ -4,23 +4,23 @@ package uuid
 
 import (
 	"cuelang.org/go/internal/core/adt"
-	"cuelang.org/go/pkg/internal"
+	"cuelang.org/go/internal/pkg"
 )
 
 func init() {
-	internal.Register("uuid", pkg)
+	pkg.Register("uuid", p)
 }
 
 var _ = adt.TopKind // in case the adt package isn't used
 
-var pkg = &internal.Package{
-	Native: []*internal.Builtin{{
+var p = &pkg.Package{
+	Native: []*pkg.Builtin{{
 		Name: "Valid",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.BottomKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret = Valid(s)
@@ -28,11 +28,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Parse",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			s := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Parse(s)
@@ -40,11 +40,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToString",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.String(0)
 			if c.Do() {
 				c.Ret = ToString(x)
@@ -52,11 +52,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "URN",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = URN(x)
@@ -64,11 +64,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "FromInt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.IntKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			i := c.BigInt(0)
 			if c.Do() {
 				c.Ret, c.Err = FromInt(i)
@@ -76,11 +76,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "ToInt",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.String(0)
 			if c.Do() {
 				c.Ret = ToInt(x)
@@ -88,11 +88,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Variant",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Variant(x)
@@ -100,11 +100,11 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "Version",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 		},
 		Result: adt.IntKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			x := c.String(0)
 			if c.Do() {
 				c.Ret, c.Err = Version(x)
@@ -112,12 +112,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "SHA1",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			space, data := c.String(0), c.Bytes(1)
 			if c.Do() {
 				c.Ret, c.Err = SHA1(space, data)
@@ -125,12 +125,12 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name: "MD5",
-		Params: []internal.Param{
+		Params: []pkg.Param{
 			{Kind: adt.StringKind},
 			{Kind: adt.BytesKind | adt.StringKind},
 		},
 		Result: adt.StringKind,
-		Func: func(c *internal.CallCtxt) {
+		Func: func(c *pkg.CallCtxt) {
 			space, data := c.String(0), c.Bytes(1)
 			if c.Do() {
 				c.Ret, c.Err = MD5(space, data)


### PR DESCRIPTION
This change is required because we need to import the package from
cuelang.org/go/cue/wasm.

Tweak pkg/gen/gen.go to generate code with the new import paths.
Also tweak a couple of manually-written files from pkg/... then run
go generate.

Signed-off-by: Aram Hăvărneanu <aram@mgk.ro>
Change-Id: I87edf4160adc0dbba34f4c1c06fc035e2ca60c41
