### PR TITLE
internal/ci: always force push to trybot repo

### DIFF
--- a/.github/workflows/push_tip_to_trybot.yml
+++ b/.github/workflows/push_tip_to_trybot.yml
@@ -33,5 +33,9 @@ jobs:
           git remote add origin https://review.gerrithub.io/a/cue-lang/cue
           git remote add trybot https://github.com/cue-lang/cue-trybot
           git fetch origin "${{ github.ref }}"
-          git push trybot "FETCH_HEAD:${{ github.ref }}"
+          for try in {1..20}
+          do
+          	echo Push to trybot try $try
+          	git push -f trybot "FETCH_HEAD:${{ github.ref }}"
+          done
     if: ${{github.repository == 'cue-lang/cue'}}

--- a/internal/ci/base/gerrithub.cue
+++ b/internal/ci/base/gerrithub.cue
@@ -73,7 +73,11 @@ pushTipToTrybotWorkflow: json.#Workflow & {
 						git remote add origin \(gerritHubRepositoryURL)
 						git remote add trybot \(trybotRepositoryURL)
 						git fetch origin "${{ github.ref }}"
-						git push trybot "FETCH_HEAD:${{ github.ref }}"
+						for try in {1..20}
+						do
+							echo Push to trybot try $try
+							git push -f trybot "FETCH_HEAD:${{ github.ref }}"
+						done
 						"""
 			},
 		]


### PR DESCRIPTION
As part of the new CI approach we will force push to master in the
trybot repo to trigger CI runs. This means that we cannot assume that a
non-force push is sufficient for a new commit to master as we currently
can.

Fix that by force pushing in all situations.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I2443df7b77d0734f5f2f0741fbdd5423627764fd
