### PR TITLE
internal/ci: switch to actions/setup-go@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Restore git file modification times
         uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: 1.19.7
       - name: Setup qemu
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Restore git file modification times
         uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: ${{ matrix.go-version }}
       - id: go-mod-cache-dir
         name: Get go mod cache directory

--- a/internal/ci/base/github.cue
+++ b/internal/ci/base/github.cue
@@ -16,8 +16,10 @@ bashWorkflow: json.#Workflow & {
 
 installGo: json.#step & {
 	name: "Install Go"
-	uses: "actions/setup-go@v3"
+	uses: "actions/setup-go@v4"
 	with: {
+		// We do our own caching in setupGoActionsCaches.
+		cache:        false
 		"go-version": *"${{ matrix.go-version }}" | string
 	}
 }
@@ -139,6 +141,8 @@ setupGoActionsCaches: {
 	// pre is the list of steps required to establish and initialise the correct
 	// caches for Go-based workflows.
 	[
+		// TODO: once https://github.com/actions/setup-go/issues/54 is fixed,
+		// we could use `go env` outputs from the setup-go step.
 		json.#step & {
 			name: "Get go mod cache directory"
 			id:   goModCacheDirID


### PR DESCRIPTION
The only breaking change is that caching is on by default now.
It's decent by default, caching both GOCACHE and GOMODCACHE
as reported by `go env`.

However, we already do our own caching in a similar vein,
and we're more careful to keep the caches trimmed down.
For that reason, keep the automatic caching turned off.

While looking at this code again, I was reminded that setup-go already
runs `go env`, so it could be giving us GOCACHE and GOMODCACHE directly.
Sure enough, someone already suggested this in the issue tracker,
so add a TODO to hopefully switch to it in the near future.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: Ia6b8be3e79b53cb13f68c927674a29e57f164d02
