### PR TITLE
internal/ci: bump GoRelease to v1.16.2 ahead of v0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           install-only: true
-          version: v1.13.1
+          version: v1.16.2
       - name: Run GoReleaser with CUE
         run: cue cmd release
         working-directory: ./internal/ci/goreleaser

--- a/internal/ci/repo/repo.cue
+++ b/internal/ci/repo/repo.cue
@@ -37,7 +37,7 @@ latestStableGo: "1.20.x"
 // so we instead pin a specific Go release.
 pinnedReleaseGo: "1.20.2"
 
-goreleaserVersion: "v1.13.1"
+goreleaserVersion: "v1.16.2"
 
 // zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
 // When we create a release branch for v0.$X.0, it's likely that commits on the


### PR DESCRIPTION
Will test on ci/test.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ic8c29cd7c173935cafba498cf5ed4c69dd75dc2d
