### PR TITLE
internal/ci: bump GoRelease to v1.16.2 ahead of v0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           install-only: true
-          version: v1.13.1
+          version: v1.16.2
       - name: Run GoReleaser with CUE
         run: cue cmd release
         working-directory: ./internal/ci/goreleaser

--- a/internal/ci/goreleaser/goreleaser.cue
+++ b/internal/ci/goreleaser/goreleaser.cue
@@ -29,6 +29,7 @@ config: {
 		]
 	}]
 	archives: [{
+		rlcp:          true
 		name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
 		files: [
 			"LICENSE",

--- a/internal/ci/goreleaser/goreleaser_tool.cue
+++ b/internal/ci/goreleaser/goreleaser_tool.cue
@@ -55,7 +55,7 @@ command: release: {
 	}
 
 	let goreleaserCmd = [
-		"goreleaser", "release", "-f", "-", "--rm-dist",
+		"goreleaser", "release", "-f", "-", "--clean",
 
 		// Only run the full release when running on GitHub actions for a release tag.
 		// Keep in sync with repo.releaseTagPattern, which is a globbing pattern

--- a/internal/ci/repo/repo.cue
+++ b/internal/ci/repo/repo.cue
@@ -37,7 +37,7 @@ latestStableGo: "1.20.x"
 // so we instead pin a specific Go release.
 pinnedReleaseGo: "1.20.2"
 
-goreleaserVersion: "v1.13.1"
+goreleaserVersion: "v1.16.2"
 
 // zeroReleaseTagSuffix is the suffix used to identify all "zero" releases.
 // When we create a release branch for v0.$X.0, it's likely that commits on the


### PR DESCRIPTION
Also make configuration changes in line with deprecations:

* Move from using --rm-dist -> --clean
  (https://goreleaser.com/deprecations/#-rm-dist)
* Set rlcp: true for archives (per
  https://goreleaser.com/deprecations/#archivesrlcp)

Will test on ci/test.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ic8c29cd7c173935cafba498cf5ed4c69dd75dc2d
