### PR TITLE
internal/ci: use D: drive for GOCACHE and GOMODCACHE on Windows

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -42,12 +42,18 @@ jobs:
         with:
           cache: false
           go-version: ${{ matrix.go-version }}
+      - if: runner.os == 'Windows'
+        name: Get go mod cache directory
+        run: |-
+          go env -w GOCACHE=/d/tmp/go/cache
+          go env -w GOMODCACHE=/d/tmp/go/modcache
       - id: go-mod-cache-dir
         name: Get go mod cache directory
         run: echo "dir=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
       - id: go-cache-dir
         name: Get go build/test cache directory
         run: echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - run: go env
       - if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-branch.'))
         uses: actions/cache@v3
         with:

--- a/internal/ci/base/github.cue
+++ b/internal/ci/base/github.cue
@@ -141,6 +141,15 @@ setupGoActionsCaches: {
 	// pre is the list of steps required to establish and initialise the correct
 	// caches for Go-based workflows.
 	[
+		// Set special cache locations on windows
+		json.#step & {
+			if:   "runner.os == 'Windows'"
+			name: "Get go mod cache directory"
+			run: """
+				go env -w GOCACHE=/d/tmp/go/cache
+				go env -w GOMODCACHE=/d/tmp/go/modcache
+				"""
+		},
 		// TODO: once https://github.com/actions/setup-go/issues/54 is fixed,
 		// we could use `go env` outputs from the setup-go step.
 		json.#step & {
@@ -152,6 +161,9 @@ setupGoActionsCaches: {
 			name: "Get go build/test cache directory"
 			id:   goCacheDirID
 			run:  #"echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}"#
+		},
+		json.#step & {
+			run: "go env"
 		},
 		for _, v in [
 			{


### PR DESCRIPTION
This is an attempt to speed up our Windows runners.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I8c3821292222f64a0f04dcc69eff9d312cade5ba
