### PR TITLE
cue/load: minimal module fetching implementation

### DIFF
--- a/cue/load/internal/registrytest/registry.go
+++ b/cue/load/internal/registrytest/registry.go
@@ -1,0 +1,331 @@
+package registrytest
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+	"golang.org/x/mod/zip"
+	"golang.org/x/tools/txtar"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+)
+
+// New starts a registry instance that serves modules found inside the
+// _registry path inside ar. The protocol that it serves is that of the
+// Go proxy, documented here: https://go.dev/ref/mod#goproxy-protocol
+//
+// Each module should be inside a directory named path_vers, where
+// slashes in path have been replaced with underscores and should
+// contain a cue.mod/module.cue file holding the module info.
+//
+// The Registry should be closed after use.
+func New(ar *txtar.Archive) *Registry {
+	h, err := newHandler(ar)
+	if err != nil {
+		panic(err)
+	}
+	srv := httptest.NewServer(h)
+	return &Registry{
+		srv: srv,
+	}
+}
+
+type Registry struct {
+	srv *httptest.Server
+}
+
+func (r *Registry) Close() {
+	r.srv.Close()
+}
+
+// URL returns the base URL for the registry.
+func (r *Registry) URL() string {
+	return r.srv.URL
+}
+
+type handler struct {
+	modules []*moduleContent
+}
+
+func newHandler(ar *txtar.Archive) (*handler, error) {
+	ctx := cuecontext.New()
+	modules := make(map[string]*moduleContent)
+	for _, f := range ar.Files {
+		path := strings.TrimPrefix(f.Name, "_registry/")
+		if len(path) == len(f.Name) {
+			continue
+		}
+		modver, rest, ok := strings.Cut(path, "/")
+		if !ok {
+			return nil, fmt.Errorf("cannot have regular file inside _registry")
+		}
+		content := modules[modver]
+		if content == nil {
+			content = &moduleContent{}
+			modules[modver] = content
+		}
+		content.files = append(content.files, txtar.File{
+			Name: rest,
+			Data: f.Data,
+		})
+	}
+	for modver, content := range modules {
+		if err := content.initVersion(ctx, modver); err != nil {
+			return nil, fmt.Errorf("cannot determine version for module in %q: %v", modver, err)
+		}
+	}
+	mods := make([]*moduleContent, 0, len(modules))
+	for _, m := range modules {
+		mods = append(mods, m)
+	}
+	return &handler{
+		modules: mods,
+	}, nil
+}
+
+var modulePath = cue.MakePath(cue.Str("module"))
+
+func modulePathFromModFile(ctx *cue.Context, data []byte) (string, error) {
+	v := ctx.CompileBytes(data)
+	if err := v.Err(); err != nil {
+		return "", fmt.Errorf("invalid module.cue syntax: %v", err)
+	}
+	v = v.LookupPath(modulePath)
+	s, err := v.String()
+	if err != nil {
+		return "", fmt.Errorf("cannot get module value from module.cue file: %v", err)
+	}
+	if s == "" {
+		return "", fmt.Errorf("empty module directive")
+	}
+	// TODO check for valid module path?
+	return s, nil
+}
+
+func (r *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	mreq, err := parseReq(req.URL.Path)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot parse request %q: %v", req.URL.Path, err), http.StatusBadRequest)
+		return
+	}
+	switch mreq.kind {
+	case reqMod:
+		data, err := r.getMod(mreq)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("cannot get module: %v", err), http.StatusNotFound)
+			return
+		}
+		// TODO content type
+		w.Write(data)
+	case reqZip:
+		data, err := r.getZip(mreq)
+		if err != nil {
+			// TODO this can fail for non-NotFound reasons too.
+			http.Error(w, fmt.Sprintf("cannot get module contents: %v", err), http.StatusNotFound)
+			return
+		}
+		// TODO content type
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(data)
+	default:
+		http.Error(w, "not implemented yet", http.StatusInternalServerError)
+	}
+}
+
+func (r *handler) getMod(req *request) ([]byte, error) {
+	for _, m := range r.modules {
+		if m.version == req.version {
+			return m.getMod(), nil
+		}
+	}
+	return nil, fmt.Errorf("no module found for %v", req.version)
+}
+
+func (r *handler) getZip(req *request) ([]byte, error) {
+	for _, m := range r.modules {
+		if m.version == req.version {
+			// TODO write this to somewhere else temporary before
+			// writing to HTTP response.
+			var buf bytes.Buffer
+			if err := m.writeZip(&buf); err != nil {
+				return nil, err
+			}
+			return buf.Bytes(), nil
+		}
+	}
+	return nil, fmt.Errorf("no module found for %v", req.version)
+}
+
+type moduleContent struct {
+	version module.Version
+	files   []txtar.File
+}
+
+func (c *moduleContent) writeZip(w io.Writer) error {
+	files := make([]zip.File, len(c.files))
+	for i := range c.files {
+		files[i] = zipFile{&c.files[i]}
+	}
+	return zip.Create(w, c.version, files)
+}
+
+type zipFile struct {
+	f *txtar.File
+}
+
+// Path implements zip.File.Path.
+func (f zipFile) Path() string {
+	return f.f.Name
+}
+
+// Lstat implements zip.File.Lstat.
+func (f zipFile) Lstat() (os.FileInfo, error) {
+	return f, nil
+}
+
+func (f zipFile) Open() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(f.f.Data)), nil
+}
+
+// Name implements fs.FileInfo.Name.
+func (f zipFile) Name() string {
+	return path.Base(f.f.Name)
+}
+
+// Mode implements fs.FileInfo.Mode.
+func (f zipFile) Mode() os.FileMode {
+	return 0
+}
+
+// Size implements fs.FileInfo.Size.
+func (f zipFile) Size() int64 {
+	return int64(len(f.f.Data))
+}
+
+func (f zipFile) IsDir() bool {
+	return false
+}
+func (f zipFile) ModTime() time.Time {
+	return time.Time{}
+}
+func (f zipFile) Sys() any {
+	return nil
+}
+
+func (c *moduleContent) getMod() []byte {
+	for _, f := range c.files {
+		if f.Name == "cue.mod/module.cue" {
+			return f.Data
+		}
+	}
+	panic(fmt.Errorf("no module.cue file found in %v", c.version))
+}
+
+func (c *moduleContent) initVersion(ctx *cue.Context, versDir string) error {
+	for _, f := range c.files {
+		if f.Name != "cue.mod/module.cue" {
+			continue
+		}
+		mod, err := modulePathFromModFile(ctx, f.Data)
+		if err != nil {
+			return fmt.Errorf("invalid module file in %q: %v", path.Join(versDir, f.Name), err)
+		}
+		if c.version.Path != "" {
+			return fmt.Errorf("multiple module.cue files")
+		}
+		c.version.Path = mod
+		mod = strings.ReplaceAll(mod, "/", "_") + "_"
+		vers := strings.TrimPrefix(versDir, mod)
+		if len(vers) == len(versDir) {
+			return fmt.Errorf("module path %q in module.cue does not match directory %q", c.version.Path, versDir)
+		}
+		if !semver.IsValid(vers) {
+			return fmt.Errorf("module version %q is not valid", vers)
+		}
+		c.version.Version = vers
+	}
+	if c.version.Path == "" {
+		return fmt.Errorf("no module.cue file found in %q", versDir)
+	}
+	return nil
+}
+
+type reqKind int
+
+const (
+	reqInvalid reqKind = iota
+	reqLatest
+	reqList
+	reqMod
+	reqZip
+	reqInfo
+)
+
+type request struct {
+	version module.Version
+	kind    reqKind
+}
+
+func parseReq(urlPath string) (*request, error) {
+	urlPath = strings.TrimPrefix(urlPath, "/")
+	i := strings.LastIndex(urlPath, "/@")
+	if i == -1 {
+		return nil, fmt.Errorf("no @ found in path")
+	}
+	if i == 0 {
+		return nil, fmt.Errorf("empty module name in path")
+	}
+	var req request
+	mod, rest := urlPath[:i], urlPath[i+1:]
+	req.version.Path = mod
+	qual, rest, ok := strings.Cut(rest, "/")
+	if qual == "@latest" {
+		if ok {
+			return nil, fmt.Errorf("invalid @latest request")
+		}
+		// $base/$module/@latest
+		req.kind = reqLatest
+		return &req, nil
+	}
+	if qual != "@v" {
+		return nil, fmt.Errorf("invalid @ in request")
+	}
+	if !ok {
+		return nil, fmt.Errorf("no qualifier after @")
+	}
+	if rest == "list" {
+		// $base/$module/@v/list
+		req.kind = reqList
+		return &req, nil
+	}
+	i = strings.LastIndex(rest, ".")
+	if i == -1 {
+		return nil, fmt.Errorf("no . found after @")
+	}
+	vers, rest := rest[:i], rest[i+1:]
+	if len(vers) == 0 {
+		return nil, fmt.Errorf("empty version string")
+	}
+	req.version.Version = vers
+	switch rest {
+	case "info":
+		req.kind = reqInfo
+	case "mod":
+		req.kind = reqMod
+	case "zip":
+		req.kind = reqZip
+	default:
+		return nil, fmt.Errorf("unknown request kind %q", rest)
+	}
+	return &req, nil
+}

--- a/cue/load/internal/registrytest/registry_test.go
+++ b/cue/load/internal/registrytest/registry_test.go
@@ -1,0 +1,99 @@
+package registrytest
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+func TestRegistry(t *testing.T) {
+	const testDir = "testdata"
+	files, err := os.ReadDir(testDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, fi := range files {
+		name := fi.Name()
+		if fi.IsDir() || filepath.Ext(name) != ".txtar" {
+			continue
+		}
+		ar, err := txtar.ParseFile(filepath.Join(testDir, fi.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Run(strings.TrimSuffix(name, ".txtar"), func(t *testing.T) {
+			r := New(ar)
+			defer r.Close()
+			runTest(t, r.URL(), string(ar.Comment), ar)
+		})
+	}
+}
+
+func runTest(t *testing.T, registry string, script string, ar *txtar.Archive) {
+	var resp *http.Response
+	var respBody []byte
+	for _, line := range strings.Split(script, "\n") {
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		args := strings.Fields(line)
+		if len(args) == 0 || args[0] == "" {
+			t.Fatalf("invalid line %q", line)
+		}
+		switch args[0] {
+		case "GET":
+			if len(args) != 2 {
+				t.Fatalf("usage: GET $url")
+			}
+			resp1, err := http.Get(registry + "/" + args[1])
+			if err != nil {
+				t.Fatalf("GET failed: %v", err)
+			}
+			respBody, _ = io.ReadAll(resp1.Body)
+			resp1.Body.Close()
+			resp = resp1
+		case "body":
+			if len(args) != 3 {
+				t.Fatalf("usage: body code file")
+			}
+			wantCode, err := strconv.Atoi(args[1])
+			if err != nil {
+				t.Fatalf("invalid code %q", args[1])
+			}
+			wantBody, err := getFile(ar, args[2])
+			if err != nil {
+				t.Fatalf("cannot open file for body comparison: %v", err)
+			}
+			if resp == nil {
+				t.Fatalf("no previous GET request to check body against")
+			}
+			if resp.StatusCode != wantCode {
+				t.Errorf("unexpected GET response code; got %v want %v", wantCode, resp.StatusCode)
+			}
+			if string(respBody) != string(wantBody) {
+				t.Errorf("unexpected GET response\ngot %q\nwant %q", respBody, wantBody)
+			}
+		default:
+			t.Fatalf("unknown command %q", line)
+		}
+	}
+}
+
+func getFile(ar *txtar.Archive, name string) ([]byte, error) {
+	name = path.Clean(name)
+	for _, f := range ar.Files {
+		if path.Clean(f.Name) == name {
+			return f.Data, nil
+		}
+	}
+	return nil, fmt.Errorf("file %q not found in txtar archive", name)
+}

--- a/cue/load/internal/registrytest/testdata/simple.txtar
+++ b/cue/load/internal/registrytest/testdata/simple.txtar
@@ -1,0 +1,54 @@
+GET example.com/@v/v0.0.1.mod
+body 200 _registry/example.com_v0.0.1/cue.mod/module.cue
+
+GET foo.com/bar/hello/@v/v0.2.3.mod
+body 200 _registry/foo.com_bar_hello_v0.2.3/cue.mod/module.cue
+
+-- _registry/example.com_v0.0.1/cue.mod/module.cue --
+module: "example.com"
+
+deps: {
+	"foo.com/bar/hello": v: "v0.2.3"
+	"bar.com": v: "v0.5.0"
+}
+-- _registry/example.com_v0.0.1/top.cue --
+package main
+
+import a "foo.com/bar/hello"
+a
+main: "main"
+-- _registry/foo.com_bar_hello_v0.2.3/cue.mod/module.cue --
+module: "foo.com/bar/hello"
+
+deps: {
+	"bar.com": v: "v0.0.2"
+	"baz.org": v: "v0.10.1"
+}
+-- _registry/foo.com_bar_hello_v0.2.3/x.cue --
+package hello
+import (
+	a "bar.com"
+	b "baz.org"
+)
+"foo.com/bar/hello": "v0.2.3"
+a
+b
+-- _registry/bar.com_v0.0.2/cue.mod/module.cue --
+module: "bar.com"
+
+deps: "baz.org": v: "v0.1.2"
+-- _registry/bar.com_v0.0.2/bar/x.cue --
+package bar
+
+import a "baz.org/baz"
+
+"bar.com": "v0.0.2"
+a
+-- _registry/baz.org_v0.10.1/cue.mod/module.cue --
+module: "baz.org"
+-- _registry/baz.org_v0.10.1/baz.cue --
+"baz.org": "v0.10.1"
+
+-- _registry/baz.org_v0.1.2/cue.mod/module.cue --
+module: "baz.org"
+"baz.org": "v0.1.2"

--- a/cue/load/loader.go
+++ b/cue/load/loader.go
@@ -35,16 +35,20 @@ import (
 )
 
 type loader struct {
-	cfg      *Config
-	tagger   *tagger
-	stk      importStack
-	loadFunc build.LoadFunc
+	cfg       *Config
+	tagger    *tagger
+	stk       importStack
+	loadFunc  build.LoadFunc
+	deps      *dependencies
+	regClient *registryClient
 }
 
-func newLegacyLoader(c *Config, tg *tagger) *loader {
+func newLoader(c *Config, tg *tagger, deps *dependencies, regClient *registryClient) *loader {
 	l := &loader{
-		cfg:    c,
-		tagger: tg,
+		cfg:       c,
+		tagger:    tg,
+		deps:      deps,
+		regClient: regClient,
 	}
 	l.loadFunc = l._loadFunc
 	return l

--- a/cue/load/loader_common.go
+++ b/cue/load/loader_common.go
@@ -51,28 +51,6 @@ const (
 	allowAnonymous
 )
 
-// loaderIntf represents the interface in common between
-// the non-module loader and the module-aware loader.
-type loaderIntf interface {
-	// loader returns the instance loading function defined by
-	// the loader.
-	buildLoadFunc() build.LoadFunc
-
-	// importPaths returns the matching paths to use for the given command line.
-	// It calls ImportPathsQuiet and then WarnUnmatched.
-	importPaths(patterns []string) []*match
-
-	// cueFilesPackage creates a package for building a collection of CUE files
-	// (typically named on the command line).
-	cueFilesPackage(files []*build.File) *build.Instance
-}
-
-func newLoader(c *Config, tg *tagger) loaderIntf {
-	// TODO when modules are enabled, return a different
-	// implementation of loaderIntf.
-	return newLegacyLoader(c, tg)
-}
-
 func rewriteFiles(p *build.Instance, root string, isLocal bool) {
 	p.Root = root
 

--- a/cue/load/loader_test.go
+++ b/cue/load/loader_test.go
@@ -62,7 +62,7 @@ module: invalid module.cue file: conflicting values 123 and "" (mismatched types
     $CWD/testdata/badmod/cue.mod/module.cue:2:9
 module: invalid module.cue file: conflicting values 123 and =~"^[^@]+$" (mismatched types int and string):
     $cueroot/cue/load/moduleschema.cue:4:10
-    $cueroot/cue/load/moduleschema.cue:9:21
+    $cueroot/cue/load/moduleschema.cue:21:21
     $CWD/testdata/badmod/cue.mod/module.cue:2:9
 path:   ""
 module: ""

--- a/cue/load/module.go
+++ b/cue/load/module.go
@@ -3,14 +3,15 @@ package load
 import (
 	_ "embed"
 	"io"
+	"strings"
 
 	"path/filepath"
 
-	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/errors"
-	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/load/internal/mvs"
 	"cuelang.org/go/cue/token"
-	"cuelang.org/go/internal/core/runtime"
+	"github.com/rogpeppe/go-internal/semver"
+	"golang.org/x/mod/module"
 )
 
 //go:embed moduleschema.cue
@@ -18,6 +19,30 @@ var moduleSchema []byte
 
 type modFile struct {
 	Module string `json:"module"`
+	Deps   map[string]*modDep
+}
+
+// versions returns all the modules that are dependended on by
+// the module file.
+func (mf *modFile) versions() []module.Version {
+	if len(mf.Deps) == 0 {
+		// It's important to return nil here because otherwise the
+		// "mistake: chose versions" panic in mvs will trigger
+		// on an empty version list.
+		return nil
+	}
+	vs := make([]module.Version, 0, len(mf.Deps))
+	for m, dep := range mf.Deps {
+		vs = append(vs, module.Version{
+			Path:    m,
+			Version: dep.Version,
+		})
+	}
+	return vs
+}
+
+type modDep struct {
+	Version string `json:"v"`
 }
 
 // loadModule loads the module file, resolves and downloads module
@@ -44,31 +69,11 @@ func (c *Config) loadModule() error {
 	if err != nil {
 		return err
 	}
-
-	// TODO: move to full build again
-	file, err := parser.ParseFile(mod, data)
+	mf, err := parseModuleFile(data, mod)
 	if err != nil {
-		return errors.Wrapf(err, token.NoPos, "invalid module.cue file")
+		return err
 	}
-	// TODO disallow non-data-mode CUE.
-
-	ctx := (*cue.Context)(runtime.New())
-	schemav := ctx.CompileBytes(moduleSchema, cue.Filename("$cueroot/cue/load/moduleschema.cue"))
-	if err := schemav.Validate(); err != nil {
-		return errors.Wrapf(err, token.NoPos, "internal error: invalid CUE module.cue schema")
-	}
-	v := ctx.BuildFile(file)
-	if err := v.Validate(cue.Concrete(true)); err != nil {
-		return errors.Wrapf(err, token.NoPos, "invalid module.cue file")
-	}
-	v = v.Unify(schemav)
-	if err := v.Validate(); err != nil {
-		return errors.Wrapf(err, token.NoPos, "invalid module.cue file")
-	}
-	var mf modFile
-	if err := v.Decode(&mf); err != nil {
-		return errors.Wrapf(err, token.NoPos, "internal error: cannot decode into modFile struct (\nfile %q\ncontents %q\nvalue %#v\n)", mod, data, v)
-	}
+	c.modFile = mf
 	if mf.Module == "" {
 		// Backward compatibility: allow empty module.cue file.
 		// TODO maybe check that the rest of the fields are empty too?
@@ -78,6 +83,98 @@ func (c *Config) loadModule() error {
 		return errors.Newf(token.NoPos, "inconsistent modules: got %q, want %q", mf.Module, c.Module)
 	}
 	c.Module = mf.Module
-	c.modFile = &mf
 	return nil
+}
+
+type dependencies struct {
+	versions []module.Version
+}
+
+// lookup returns the module corresponding to the given import path, and the relative path
+// of the package beneath that.
+//
+// It assumes that modules are not nested.
+func (deps *dependencies) lookup(pkgPath importPath) (v module.Version, subPath string, ok bool) {
+	for _, dep := range deps.versions {
+		if subPath, ok := isParent(importPath(dep.Path), pkgPath); ok {
+			return dep, subPath, true
+		}
+	}
+	return module.Version{}, "", false
+}
+
+// resolveDependencies resolves all the versions of all the modules in the given module file,
+// using regClient to fetch dependency information.
+func resolveDependencies(mainModFile *modFile, regClient *registryClient) (*dependencies, error) {
+	vs, err := mvs.BuildList(mainModFile.versions(), &mvsReqs{
+		mainModule: mainModFile,
+		regClient:  regClient,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &dependencies{
+		versions: vs,
+	}, nil
+}
+
+// mvsReqs implements mvs.Reqs by fetching information using
+// regClient.
+type mvsReqs struct {
+	mainModule *modFile
+	regClient  *registryClient
+}
+
+// Required implements mvs.Reqs.Required.
+func (reqs *mvsReqs) Required(m module.Version) (vs []module.Version, err error) {
+	if m.Path == reqs.mainModule.Module {
+		return reqs.mainModule.versions(), nil
+	}
+	mf, err := reqs.regClient.fetchModFile(m)
+	if err != nil {
+		return nil, err
+	}
+	return mf.versions(), nil
+}
+
+// Required implements mvs.Reqs.Max.
+func (reqs *mvsReqs) Max(v1, v2 string) string {
+	if cmpVersion(v1, v2) < 0 {
+		return v2
+	}
+	return v1
+}
+
+// cmpVersion implements the comparison for versions in the module loader.
+//
+// It is consistent with semver.Compare except that as a special case,
+// the version "" is considered higher than all other versions.
+// The main module (also known as the target) has no version and must be chosen
+// over other versions of the same module in the module dependency graph.
+func cmpVersion(v1, v2 string) int {
+	if v2 == "" {
+		if v1 == "" {
+			return 0
+		}
+		return -1
+	}
+	if v1 == "" {
+		return 1
+	}
+	return semver.Compare(v1, v2)
+}
+
+// isParent reports whether the module modPath contains the package with the given
+// path, and if so, returns its relative path within that module.
+func isParent(modPath, pkgPath importPath) (subPath string, ok bool) {
+	if !strings.HasPrefix(string(pkgPath), string(modPath)) {
+		return "", false
+	}
+	if len(pkgPath) == len(modPath) {
+		return ".", true
+	}
+	if pkgPath[len(modPath)] != '/' {
+		return "", false
+	}
+	return string(pkgPath[len(modPath)+1:]), true
 }

--- a/cue/load/module_test.go
+++ b/cue/load/module_test.go
@@ -1,0 +1,40 @@
+package load_test
+
+import (
+	"fmt"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/load/internal/registrytest"
+	"cuelang.org/go/internal/cuetxtar"
+)
+
+func TestModuleFetch(t *testing.T) {
+	test := cuetxtar.TxTarTest{
+		Root: "./testdata/testfetch",
+		Name: "modfetch",
+	}
+	test.Run(t, func(t *cuetxtar.Test) {
+		r := registrytest.New(t.Archive)
+		defer r.Close()
+		t.LoadConfig.Registry = r.URL()
+		ctx := cuecontext.New()
+		insts := t.RawInstances()
+		if len(insts) != 1 {
+			t.Fatalf("wrong instance count; got %d want 1", len(insts))
+		}
+		inst := insts[0]
+		if inst.Err != nil {
+			errors.Print(t.Writer("error"), inst.Err, &errors.Config{
+				ToSlash: true,
+			})
+			return
+		}
+		v := ctx.BuildInstance(inst)
+		if err := v.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprintf(t, "%v\n", v)
+	})
+}

--- a/cue/load/moduleschema.cue
+++ b/cue/load/moduleschema.cue
@@ -3,6 +3,18 @@
 // directory and an empty module directive.
 module?: #Module | ""
 
+// deps holds dependency information for modules, keyed by module path.
+deps?: [#Module]: {
+	// TODO numexist(<=1, replace, replaceAll)
+	// TODO numexist(>=1, v, exclude, replace, replaceAll)
+
+	// v indicates the required version of the module.
+	// It is usually a #Semver but it can also name a branch
+	// of the module. cue mod tidy will rewrite such branch
+	// names to their canonical versions.
+	v?: string
+}
+
 // #Module constraints a module path.
 // TODO encode the module path rules as regexp:
 // WIP: (([\-_~a-zA-Z0-9][.\-_~a-zA-Z0-9]*[\-_~a-zA-Z0-9])|([\-_~a-zA-Z0-9]))(/([\-_~a-zA-Z0-9][.\-_~a-zA-Z0-9]*[\-_~a-zA-Z0-9])|([\-_~a-zA-Z0-9]))*

--- a/cue/load/registry.go
+++ b/cue/load/registry.go
@@ -1,0 +1,137 @@
+package load
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/zip"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/token"
+	"cuelang.org/go/internal/core/runtime"
+)
+
+// registryClient implements the protocol for talking to
+// the registry server.
+type registryClient struct {
+	// TODO caching
+	registryURL string
+	cacheDir    string
+}
+
+// newRegistryClient returns a registry client that talks to
+// the given base URL and stores downloaded module information
+// in the given cache directory. It assumes that information
+// in the registry is immutable, so if it's in the cache, a module
+// will not be downloaded again.
+func newRegistryClient(registryURL, cacheDir string) *registryClient {
+	return &registryClient{
+		registryURL: registryURL,
+		cacheDir:    cacheDir,
+	}
+}
+
+// fetchModFile returns the parsed contents of the cue.mod/module.cue file
+// for the given module.
+func (c *registryClient) fetchModFile(m module.Version) (*modFile, error) {
+	data, err := c.fetchRawModFile(m)
+	if err != nil {
+		return nil, err
+	}
+	mf, err := parseModuleFile(data, path.Join(m.Path, "cue.mod/module.cue"))
+	if err != nil {
+		return nil, err
+	}
+	return mf, nil
+}
+
+// fetchModFile returns the contents of the cue.mod/module.cue file
+// for the given module without parsing it.
+func (c *registryClient) fetchRawModFile(m module.Version) ([]byte, error) {
+	resp, err := http.Get(c.registryURL + "/" + m.Path + "/@v/" + m.Version + ".mod")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get HTTP response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("module.cue HTTP GET request failed: %s", body)
+	}
+	return body, nil
+}
+
+// getModContents downloads the module with the given version
+// and returns the directory where it's stored.
+func (c *registryClient) getModContents(m module.Version) (string, error) {
+	modPath := filepath.Join(c.cacheDir, fmt.Sprintf("%s@%s", m.Path, m.Version))
+	if _, err := os.Stat(modPath); err == nil {
+		return modPath, nil
+	}
+	// TODO synchronize parallel invocations
+	resp, err := http.Get(c.registryURL + "/" + m.Path + "/@v/" + m.Version + ".zip")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return "", fmt.Errorf("module.cue HTTP GET request failed: %s", body)
+	}
+	zipfile := filepath.Join(c.cacheDir, m.String()+".zip")
+	if err := os.MkdirAll(filepath.Dir(zipfile), 0o777); err != nil {
+		return "", fmt.Errorf("cannot create parent directory for zip file: %v", err)
+	}
+	f, err := os.Create(zipfile)
+	if err != nil {
+		return "", fmt.Errorf("cannot create zipfile: %v", err)
+	}
+
+	defer f.Close() // TODO check error on close
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return "", fmt.Errorf("cannot copy data to zip file %q: %v", zipfile, err)
+	}
+	if err := zip.Unzip(modPath, m, zipfile); err != nil {
+		return "", fmt.Errorf("cannot unzip %v: %v", m, err)
+	}
+	return modPath, nil
+}
+
+// parseModuleFile parses a cue.mod/module.cue file.
+// TODO move this to be closer to the modFile type definition.
+func parseModuleFile(data []byte, filename string) (*modFile, error) {
+	file, err := parser.ParseFile(filename, data)
+	if err != nil {
+		return nil, errors.Wrapf(err, token.NoPos, "invalid module.cue file %q", data)
+	}
+	// TODO disallow non-data-mode CUE.
+
+	ctx := (*cue.Context)(runtime.New())
+	schemav := ctx.CompileBytes(moduleSchema, cue.Filename("$cueroot/cue/load/moduleschema.cue"))
+	if err := schemav.Validate(); err != nil {
+		return nil, errors.Wrapf(err, token.NoPos, "internal error: invalid CUE module.cue schema")
+	}
+	v := ctx.BuildFile(file)
+	if err := v.Validate(cue.Concrete(true)); err != nil {
+		return nil, errors.Wrapf(err, token.NoPos, "invalid module.cue file")
+	}
+	v = v.Unify(schemav)
+	if err := v.Validate(); err != nil {
+		return nil, errors.Wrapf(err, token.NoPos, "invalid module.cue file")
+	}
+	var mf modFile
+	if err := v.Decode(&mf); err != nil {
+		return nil, errors.Wrapf(err, token.NoPos, "internal error: cannot decode into modFile struct (\nfile %q\ncontents %q\nvalue %#v\n)", filename, data, v)
+	}
+	return &mf, nil
+}

--- a/cue/load/testdata/testfetch/depnotfound.txtar
+++ b/cue/load/testdata/testfetch/depnotfound.txtar
@@ -1,0 +1,11 @@
+-- out/modfetch/error --
+instance: example.com@v0.0.1: module.cue HTTP GET request failed: cannot get module: no module found for example.com@v0.0.1
+
+-- cue.mod/module.cue --
+module: "main.org"
+
+deps: "example.com": v: "v0.0.1"
+
+-- main.cue --
+package main
+import _ "example.com:main"

--- a/cue/load/testdata/testfetch/nodeps.txtar
+++ b/cue/load/testdata/testfetch/nodeps.txtar
@@ -1,0 +1,11 @@
+-- out/modfetch --
+{
+	a: "hello"
+}
+-- cue.mod/module.cue --
+module: "main.org"
+
+-- main.cue --
+package main
+
+a: "hello"

--- a/cue/load/testdata/testfetch/simple.txtar
+++ b/cue/load/testdata/testfetch/simple.txtar
@@ -1,0 +1,105 @@
+-- out/modfetch --
+{
+	main:                "main"
+	"foo.com/bar/hello": "v0.2.3"
+	"bar.com":           "v0.5.0"
+	"baz.org":           "v0.10.1"
+	"example.com":       "v0.0.1"
+}
+-- cue.mod/module.cue --
+module: "main.org"
+
+deps: "example.com": v: "v0.0.1"
+
+-- main.cue --
+package main
+import "example.com:main"
+
+main
+
+-- _registry/example.com_v0.0.1/cue.mod/module.cue --
+module: "example.com"
+deps: {
+	"foo.com/bar/hello": v: "v0.2.3"
+	"bar.com": v: "v0.5.0"
+}
+
+-- _registry/example.com_v0.0.1/top.cue --
+package main
+
+import a "foo.com/bar/hello"
+a
+main: "main"
+"example.com": "v0.0.1"
+
+
+-- _registry/foo.com_bar_hello_v0.2.3/cue.mod/module.cue --
+module: "foo.com/bar/hello"
+deps: {
+	"bar.com": v: "v0.0.2"
+	"baz.org": v: "v0.10.1"
+}
+
+-- _registry/foo.com_bar_hello_v0.2.3/x.cue --
+package hello
+import (
+	a "bar.com/bar"
+	b "baz.org:baz"
+)
+"foo.com/bar/hello": "v0.2.3"
+a
+b
+
+
+-- _registry/bar.com_v0.0.2/cue.mod/module.cue --
+module: "bar.com"
+deps: "baz.org": v: "v0.0.2"
+
+-- _registry/bar.com_v0.0.2/bar/x.cue --
+package bar
+import a "baz.org:baz"
+"bar.com": "v0.0.2"
+a
+
+
+-- _registry/bar.com_v0.5.0/cue.mod/module.cue --
+module: "bar.com"
+deps: "baz.org": v: "v0.5.0"
+
+-- _registry/bar.com_v0.5.0/bar/x.cue --
+package bar
+import a "baz.org:baz"
+"bar.com": "v0.5.0"
+a
+
+
+-- _registry/baz.org_v0.0.2/cue.mod/module.cue --
+module: "baz.org"
+
+-- _registry/baz.org_v0.0.2/baz.cue --
+package baz
+"baz.org": "v0.0.2"
+
+
+-- _registry/baz.org_v0.1.2/cue.mod/module.cue --
+module: "baz.org"
+
+-- _registry/baz.org_v0.1.2/baz.cue --
+package baz
+"baz.org": "v0.1.2"
+
+
+-- _registry/baz.org_v0.5.0/cue.mod/module.cue --
+module: "baz.org"
+
+-- _registry/baz.org_v0.5.0/baz.cue --
+package baz
+"baz.org": "v0.5.0"
+
+
+-- _registry/baz.org_v0.10.1/cue.mod/module.cue --
+module: "baz.org"
+
+-- _registry/baz.org_v0.10.1/baz.cue --
+package baz
+"baz.org": "v0.10.1"


### PR DESCRIPTION
This is just a proof of concept for now - the details will probably
change, but it demonstrates MVS module version resolution and
fetching modules from a server.

Note that public behaviour does not change here - the new behavior
is only triggered by setting the `load.Config.Registry` field to a non-empty
URL.

The `Config.absDirFromImportPath` method became `loader.absDirFromImportPath`
so was moved - the only changes are to use `l.cfg` instead of `c` and the
`if l.cfg.Registry` conditional code.

Signed-off-by: Roger Peppe <rogpeppe@gmail.com>
Change-Id: I7c5e0888db780f23a6d58081e70680a48dce509f
