### PR TITLE
internal/ci: import repo package once in github package

### DIFF
--- a/.github/workflows/trybot_dispatch.yml
+++ b/.github/workflows/trybot_dispatch.yml
@@ -1,15 +1,15 @@
 # Code generated internal/ci/ci_tool.cue; DO NOT EDIT.
 
-name: Dispatch trybot
+name: Dispatch TryBot
 "on":
   - repository_dispatch
 jobs:
-  trybot:
+  TryBot:
     runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
-    if: ${{ github.event.client_payload.type == 'trybot' }}
+    if: ${{ github.event.client_payload.type == 'TryBot' }}
     steps:
       - name: Write netrc file for cueckoo Gerrithub
         run: |-
@@ -23,7 +23,7 @@ jobs:
         run: |-
           ref="$(echo ${{github.event.client_payload.payload.ref}} | sed -E 's/^refs\/changes\/[0-9]+\/([0-9]+)\/([0-9]+).*/\1\/\2/')"
           echo "gerrithub_ref=$ref" >> $GITHUB_OUTPUT
-      - name: Trigger trybot
+      - name: Trigger TryBot
         run: |-
           mkdir tmpgit
           cd tmpgit
@@ -32,9 +32,9 @@ jobs:
           git config user.email cueckoo@gmail.com
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
           git fetch https://review.gerrithub.io/a/cue-lang/cue "${{ github.event.client_payload.payload.ref }}"
-          git checkout -b trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }} FETCH_HEAD
+          git checkout -b TryBot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }} FETCH_HEAD
           git remote add origin https://github.com/cue-lang/cue-trybot
           git fetch origin "${{ github.event.client_payload.payload.branch }}"
-          git push origin trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}
+          git push origin TryBot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}
           echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
           gh pr --repo=https://github.com/cue-lang/cue-trybot create --base="${{ github.event.client_payload.payload.branch }}" --fill

--- a/internal/ci/base/gerrithub.cue
+++ b/internal/ci/base/gerrithub.cue
@@ -7,15 +7,14 @@ import (
 )
 
 trybotDispatchWorkflow: json.#Workflow & {
-	#type:                  string
-	_#branchNameExpression: "\(#type)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
-	name:                   "Dispatch \(#type)"
+	_#branchNameExpression: "\(trybot.name)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
+	name:                   "Dispatch \(trybot.name)"
 	on: ["repository_dispatch"]
 	jobs: [string]: defaults: run: shell: "bash"
 	jobs: {
-		(#type): {
+		(trybot.name): {
 			"runs-on": linuxMachine
-			if:        "${{ github.event.client_payload.type == '\(#type)' }}"
+			if:        "${{ github.event.client_payload.type == '\(trybot.name)' }}"
 			steps: [
 				writeNetrcFile,
 				// Out of the entire ref (e.g. refs/changes/38/547738/7) we only
@@ -29,7 +28,7 @@ trybotDispatchWorkflow: json.#Workflow & {
 						"""#
 				},
 				json.#step & {
-					name: "Trigger \(#type)"
+					name: "Trigger \(trybot.name)"
 					run:  """
 						mkdir tmpgit
 						cd tmpgit

--- a/internal/ci/github/evict_caches.cue
+++ b/internal/ci/github/evict_caches.cue
@@ -17,8 +17,6 @@ package github
 import (
 	"strings"
 
-	"cuelang.org/go/internal/ci/repo"
-
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -14,10 +14,6 @@
 
 package github
 
-import (
-	"cuelang.org/go/internal/ci/repo"
-)
-
 // push_tip_to_trybot "syncs" active branches to the trybot repo.
 // Since the workflow is triggered by a push to any of the branches,
 // the step only needs to sync the pushed branch.

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -17,7 +17,6 @@ package github
 import (
 	"list"
 
-	"cuelang.org/go/internal/ci/repo"
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 

--- a/internal/ci/github/repo.cue
+++ b/internal/ci/github/repo.cue
@@ -14,5 +14,15 @@
 
 package github
 
-// The trybot_dispatch workflow.
-workflows: trybot_dispatch: repo.bashWorkflow & repo.trybotDispatchWorkflow
+// This file exists to provide a single point of importing
+// the repo package. The pattern of using base and repo
+// is replicated across a number of CUE repos, and as such
+// the import path of repo varies between them. This makes
+// spotting differences and applying changes between the
+// github/*.cue files noisy. Instead, import the repo package
+// in a single file, and that keeps the different in import
+// path down to a single file.
+
+import _repo "cuelang.org/go/internal/ci/repo"
+
+repo: _repo

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -14,10 +14,6 @@
 
 package github
 
-import (
-	"cuelang.org/go/internal/ci/repo"
-)
-
 // The tip_triggers workflow. This fires for each new commit that hits the
 // default branch.
 workflows: tip_triggers: repo.bashWorkflow & {

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -17,8 +17,6 @@ package github
 import (
 	"list"
 
-	"cuelang.org/go/internal/ci/repo"
-
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -19,6 +19,4 @@ import (
 )
 
 // The trybot_dispatch workflow.
-workflows: trybot_dispatch: repo.bashWorkflow & repo.trybotDispatchWorkflow & {
-	#type: repo.trybot.key
-}
+workflows: trybot_dispatch: repo.bashWorkflow & repo.trybotDispatchWorkflow

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -16,8 +16,6 @@
 package github
 
 import (
-	"cuelang.org/go/internal/ci/repo"
-
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 


### PR DESCRIPTION
Per the comment in github/repo.cue this keeps the noise in diffs between
the configurations in this and other CUE repos down to a minimum, when
applying the same configuration pattern in those other repos.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I2df9116867b6534a4010894a37e338c8b2e0454b
