### PR TITLE
internal/ci: drop parameter from trybotDispatchWorkflow

### DIFF
--- a/internal/ci/base/gerrithub.cue
+++ b/internal/ci/base/gerrithub.cue
@@ -7,15 +7,14 @@ import (
 )
 
 trybotDispatchWorkflow: json.#Workflow & {
-	#type:                  string
-	_#branchNameExpression: "\(#type)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
-	name:                   "Dispatch \(#type)"
+	_#branchNameExpression: "\(trybot.key)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
+	name:                   "Dispatch \(trybot.key)"
 	on: ["repository_dispatch"]
 	jobs: [string]: defaults: run: shell: "bash"
 	jobs: {
-		(#type): {
+		(trybot.key): {
 			"runs-on": linuxMachine
-			if:        "${{ github.event.client_payload.type == '\(#type)' }}"
+			if:        "${{ github.event.client_payload.type == '\(trybot.key)' }}"
 			steps: [
 				writeNetrcFile,
 				// Out of the entire ref (e.g. refs/changes/38/547738/7) we only
@@ -29,7 +28,7 @@ trybotDispatchWorkflow: json.#Workflow & {
 						"""#
 				},
 				json.#step & {
-					name: "Trigger \(#type)"
+					name: "Trigger \(trybot.key)"
 					run:  """
 						mkdir tmpgit
 						cd tmpgit

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -19,6 +19,4 @@ import (
 )
 
 // The trybot_dispatch workflow.
-workflows: trybot_dispatch: repo.bashWorkflow & repo.trybotDispatchWorkflow & {
-	#type: repo.trybot.key
-}
+workflows: trybot_dispatch: repo.bashWorkflow & repo.trybotDispatchWorkflow


### PR DESCRIPTION
The name already indicates it is not reusable in any way. If at a later
date we need to make it generic and parameterised we can. For now it's
just noise.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ib644dee24e6b1a315b56c716028af7cbc0c06eba
