### PR TITLE
internal/ci/github: rename repo -> _repo

### DIFF
--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -14,15 +14,15 @@
 
 package github
 
-// push_tip_to_trybot "syncs" active branches to the trybot repo.
+// push_tip_to_trybot "syncs" active branches to the trybot _repo.
 // Since the workflow is triggered by a push to any of the branches,
 // the step only needs to sync the pushed branch.
-workflows: push_tip_to_trybot: repo.pushTipToTrybotWorkflow & {
+workflows: push_tip_to_trybot: _repo.pushTipToTrybotWorkflow & {
 	on: {
-		push: branches: repo.protectedBranchPatterns
+		push: branches: _repo.protectedBranchPatterns
 	}
 	jobs: push: {
-		"runs-on": repo.linuxMachine
-		if:        "${{github.repository == '\(repo.githubRepositoryPath)'}}"
+		"runs-on": _repo.linuxMachine
+		if:        "${{github.repository == '\(_repo.githubRepositoryPath)'}}"
 	}
 }

--- a/internal/ci/github/release.cue
+++ b/internal/ci/github/release.cue
@@ -26,7 +26,7 @@ import (
 _cueVersionRef: "${GITHUB_REF##refs/tags/}"
 
 // The release workflow
-workflows: release: repo.bashWorkflow & {
+workflows: release: _repo.bashWorkflow & {
 
 	name: "Release"
 
@@ -36,16 +36,16 @@ workflows: release: repo.bashWorkflow & {
 	concurrency: "release"
 
 	on: push: {
-		tags: [repo.releaseTagPattern, "!" + repo.zeroReleaseTagPattern]
-		branches: list.Concat([[repo.testDefaultBranch], repo.protectedBranchPatterns])
+		tags: [_repo.releaseTagPattern, "!" + _repo.zeroReleaseTagPattern]
+		branches: list.Concat([[_repo.testDefaultBranch], _repo.protectedBranchPatterns])
 	}
 	jobs: goreleaser: {
-		"runs-on": repo.linuxMachine
-		if:        "${{github.repository == '\(repo.githubRepositoryPath)'}}"
+		"runs-on": _repo.linuxMachine
+		if:        "${{github.repository == '\(_repo.githubRepositoryPath)'}}"
 		steps: [
-			for v in repo.checkoutCode {v},
-			repo.installGo & {
-				with: "go-version": repo.pinnedReleaseGo
+			for v in _repo.checkoutCode {v},
+			_repo.installGo & {
+				with: "go-version": _repo.pinnedReleaseGo
 			},
 			json.#step & {
 				name: "Setup qemu"
@@ -73,7 +73,7 @@ workflows: release: repo.bashWorkflow & {
 				uses: "goreleaser/goreleaser-action@v3"
 				with: {
 					"install-only": true
-					version:        repo.goreleaserVersion
+					version:        _repo.goreleaserVersion
 				}
 			},
 			json.#step & {
@@ -84,18 +84,18 @@ workflows: release: repo.bashWorkflow & {
 				run:                 "cue cmd release"
 				"working-directory": "./internal/ci/goreleaser"
 			},
-			repo.repositoryDispatch & {
+			_repo.repositoryDispatch & {
 				name:                  "Re-test cuelang.org"
-				if:                    repo.isReleaseTag
-				#githubRepositoryPath: repo.cuelangRepositoryPath
+				if:                    _repo.isReleaseTag
+				#githubRepositoryPath: _repo.cuelangRepositoryPath
 				#arg: {
 					event_type: "Re-test post release of \(_cueVersionRef)"
 				}
 			},
-			repo.repositoryDispatch & {
+			_repo.repositoryDispatch & {
 				name:                  "Trigger unity build"
-				if:                    repo.isReleaseTag
-				#githubRepositoryPath: repo.unityRepositoryPath
+				if:                    _repo.isReleaseTag
+				#githubRepositoryPath: _repo.unityRepositoryPath
 				#arg: {
 					event_type: "Check against CUE \(_cueVersionRef)"
 					client_payload: {

--- a/internal/ci/github/repo.cue
+++ b/internal/ci/github/repo.cue
@@ -23,6 +23,6 @@ package github
 // in a single file, and that keeps the different in import
 // path down to a single file.
 
-import _repo "cuelang.org/go/internal/ci/repo"
+import repo "cuelang.org/go/internal/ci/repo"
 
-repo: _repo
+_repo: repo

--- a/internal/ci/github/tip_triggers.cue
+++ b/internal/ci/github/tip_triggers.cue
@@ -16,17 +16,17 @@ package github
 
 // The tip_triggers workflow. This fires for each new commit that hits the
 // default branch.
-workflows: tip_triggers: repo.bashWorkflow & {
+workflows: tip_triggers: _repo.bashWorkflow & {
 
 	name: "Triggers on push to tip"
-	on: push: branches: [repo.defaultBranch]
+	on: push: branches: [_repo.defaultBranch]
 	jobs: push: {
-		"runs-on": repo.linuxMachine
-		if:        "${{github.repository == '\(repo.githubRepositoryPath)'}}"
+		"runs-on": _repo.linuxMachine
+		if:        "${{github.repository == '\(_repo.githubRepositoryPath)'}}"
 		steps: [
-			repo.repositoryDispatch & {
+			_repo.repositoryDispatch & {
 				name:                  "Trigger tip.cuelang.org deploy"
-				#githubRepositoryPath: repo.cuelangRepositoryPath
+				#githubRepositoryPath: _repo.cuelangRepositoryPath
 				#arg: {
 					event_type: "Rebuild tip against ${GITHUB_SHA}"
 					client_payload: {
@@ -34,9 +34,9 @@ workflows: tip_triggers: repo.bashWorkflow & {
 					}
 				}
 			},
-			repo.repositoryDispatch & {
+			_repo.repositoryDispatch & {
 				name:                  "Trigger unity build"
-				#githubRepositoryPath: repo.unityRepositoryPath
+				#githubRepositoryPath: _repo.unityRepositoryPath
 				#arg: {
 					event_type: "Check against ${GITHUB_SHA}"
 					client_payload: {

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,4 +15,4 @@
 package github
 
 // The trybot_dispatch workflow.
-workflows: trybot_dispatch: repo.bashWorkflow & repo.trybotDispatchWorkflow
+workflows: trybot_dispatch: _repo.bashWorkflow & _repo.trybotDispatchWorkflow

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -40,7 +40,7 @@ import (
 workflows: close({
 	[string]: json.#Workflow
 
-	(repo.trybot.key):  _
+	(_repo.trybot.key):  _
 	trybot_dispatch:    _
 	release:            _
 	tip_triggers:       _


### PR DESCRIPTION
Running cue export on the github package is a good way of tracking down
issues with workflow declarations that are otherwise impossible to find
when running cue cmd to regenerate the yml outputs. These bugs are known
about and effectively captured by #1325.

Right now, because we declare the field named base to be the package
value of the imported base package, such an export fails because there
are many fields of that package value that cannot be exported because
they are not concrete.

Fix that by making the field hidden, which allows the cue export trick
to work again.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Icd9df2beab51ff2ae34ac3eb641d6c739b01e2ce
