### PR TITLE
internal/ci: remove trybot from push branches

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -4,7 +4,6 @@ name: TryBot
 "on":
   push:
     branches:
-      - trybot/*/*
       - ci/test
       - master
       - release-branch.*

--- a/internal/ci/base/github.cue
+++ b/internal/ci/base/github.cue
@@ -176,6 +176,16 @@ setupGoActionsCaches: {
 				}
 			}
 		},
+
+		// All tests on protected branches should skip the test cache.
+		// The canonical way to do this is with -count=1. However, we
+		// want the resulting test cache to be valid and current so that
+		// subsequent CLs in the trybot repo can leverage the updated
+		// cache. Therefore, we instead perform a clean of the testcache.
+		json.#step & {
+			if:  "github.repository == '\(githubRepositoryPath)' && (\(isProtectedBranch) || github.ref == 'refs/heads/\(testDefaultBranch)')"
+			run: "go clean -testcache"
+		},
 	]
 }
 

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -26,7 +26,7 @@ workflows: trybot: _repo.bashWorkflow & {
 
 	on: {
 		push: {
-			branches: list.Concat([["trybot/*/*", _repo.testDefaultBranch], _repo.protectedBranchPatterns]) // do not run PR branches
+			branches: list.Concat([[_repo.testDefaultBranch], _repo.protectedBranchPatterns]) // do not run PR branches
 			"tags-ignore": [_repo.releaseTagPattern]
 		}
 		pull_request: {}
@@ -46,16 +46,6 @@ workflows: trybot: _repo.bashWorkflow & {
 				// cachePre must come after installing Node and Go, because the cache locations
 				// are established by running each tool.
 				for v in goCaches {v},
-
-				// All tests on protected branches should skip the test cache.
-				// The canonical way to do this is with -count=1. However, we
-				// want the resulting test cache to be valid and current so that
-				// subsequent CLs in the trybot repo can leverage the updated
-				// cache. Therefore, we instead perform a clean of the testcache.
-				json.#step & {
-					if:  "github.repository == '\(_repo.githubRepositoryPath)' && (\(_repo.isProtectedBranch) || github.ref == 'refs/heads/\(_repo.testDefaultBranch)')"
-					run: "go clean -testcache"
-				},
 
 				_repo.earlyChecks & {
 					// These checks don't vary based on the Go version or OS,


### PR DESCRIPTION
The trybots are currently triggered by PR, not a push to a branch. The
pattern trybot/*/* does not match the current 5-element form of
trybot/*/*/*/* hence why this doesn't have any negative impact, we just
remove it to keep things tidy.

Also move some common behaviour with respect to testcache clearing to be
part of the base GitHub templates.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ia9dfa937997fc65e7771ba4e42fe91e36645ed49
