### PR TITLE
internal/ci: refactor base caching pattern

### DIFF
--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -47,16 +47,6 @@ workflows: trybot: _repo.bashWorkflow & {
 				// are established by running each tool.
 				for v in goCaches {v},
 
-				// All tests on protected branches should skip the test cache.
-				// The canonical way to do this is with -count=1. However, we
-				// want the resulting test cache to be valid and current so that
-				// subsequent CLs in the trybot repo can leverage the updated
-				// cache. Therefore, we instead perform a clean of the testcache.
-				json.#step & {
-					if:  "github.repository == '\(_repo.githubRepositoryPath)' && (\(_repo.isProtectedBranch) || github.ref == 'refs/heads/\(_repo.testDefaultBranch)')"
-					run: "go clean -testcache"
-				},
-
 				_repo.earlyChecks & {
 					// These checks don't vary based on the Go version or OS,
 					// so we only need to run them on one of the matrix jobs.


### PR DESCRIPTION
We currently parameterise the setupGoActionsCaches template with an
expression that guards proctected branches. However this concept is
already well defined in base via isProtectedBranch. Therefore, remove
the #protectedBranchExpr parameter.

At the same time hoist some logic around the clearing of the testcache
as part of the setup of the Go caches. This is otherwise repeated in
every trybot workflow at least.

For some workflows that want to reuse the Go cache template but _not_
clear the testcache, we provide clearing of the testcache as a default
that can be overridden. In the case that we don't want to clear the
testcache the workflow itself can be simplified to only ever restore
from the cache.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ia100955abdb8e6db3b89cbd04e1c914c51cd514c
