### PR TITLE
internal/core/adt: use value array for Disjunction

### DIFF
--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -546,9 +546,14 @@ func toDataAll(ctx *OpContext, v BaseValue) BaseValue {
 	// to avoid issues with the closedness algorithm down the line.
 	case *Disjunction:
 		d := *x
-		d.Values = make([]*Vertex, len(x.Values))
+		d.Values = make([]Value, len(x.Values))
 		for i, v := range x.Values {
-			d.Values[i] = v.ToDataAll(ctx)
+			switch x := v.(type) {
+			case *Vertex:
+				d.Values[i] = x.ToDataAll(ctx)
+			default:
+				d.Values[i] = x
+			}
 		}
 		return &d
 
@@ -739,7 +744,7 @@ func (v *Vertex) IsClosedList() bool {
 func (v *Vertex) Accept(ctx *OpContext, f Feature) bool {
 	if x, ok := v.BaseValue.(*Disjunction); ok {
 		for _, v := range x.Values {
-			if v.Accept(ctx, f) {
+			if x, ok := v.(*Vertex); ok && x.Accept(ctx, f) {
 				return true
 			}
 		}

--- a/internal/core/adt/default.go
+++ b/internal/core/adt/default.go
@@ -56,7 +56,7 @@ func (v *Vertex) Default() *Vertex {
 		case 0:
 			return v
 		case 1:
-			w = d.Values[0].Default()
+			w = ToVertex(Default(d.Values[0]))
 		default:
 			x := *v
 			x.state = nil

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -297,6 +297,10 @@ func (c *OpContext) unify(v *Vertex, state vertexStatus) {
 			// The conjuncts will have too much information. Better have no
 			// information than incorrect information.
 			for _, d := range d.Values {
+				d, ok := d.(*Vertex)
+				if !ok {
+					continue
+				}
 				// We clear the conjuncts for now. As these disjuncts are for API
 				// use only, we will fill them out when necessary (using Defaults).
 				d.Conjuncts = nil
@@ -884,7 +888,7 @@ func isCyclePlaceholder(v BaseValue) bool {
 }
 
 func (n *nodeContext) createDisjunct() *Disjunction {
-	a := make([]*Vertex, len(n.disjuncts))
+	a := make([]Value, len(n.disjuncts))
 	p := 0
 	hasDefaults := false
 	for i, x := range n.disjuncts {

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1769,8 +1769,8 @@ type Disjunction struct {
 	Src ast.Expr
 
 	// Values are the non-error disjuncts of this expression. The first
-	// NumDefault values are default values.
-	Values []*Vertex
+	// NumDefaults values are default values.
+	Values []Value
 
 	Errors *Bottom // []bottom
 

--- a/pkg/path/pkg.go
+++ b/pkg/path/pkg.go
@@ -38,20 +38,20 @@ var (
 	// windowsDefault is the default for VolumeName.
 	windowsDefault = &adt.Disjunction{
 		NumDefaults: 1,
-		Values: append([]*adt.Vertex{
+		Values: append([]adt.Value{
 			newStr("windows"),
 			newStr("unix"),
 			newStr("plan9")}, unixOS...),
 	}
 
-	allOS = append([]*adt.Vertex{
+	allOS = append([]adt.Value{
 		newStr("unix"),
 		newStr("windows"),
 		newStr("plan9"),
 	}, unixOS...)
 
 	// These all fall back to unix
-	unixOS = []*adt.Vertex{
+	unixOS = []adt.Value{
 		newStr("aix"),
 		newStr("android"),
 		newStr("darwin"),
@@ -70,10 +70,8 @@ var (
 	}
 )
 
-func newStr(s string) *adt.Vertex {
-	v := &adt.Vertex{}
-	v.SetValue(nil, &adt.String{Str: s})
-	return v
+func newStr(s string) adt.Value {
+	return &adt.String{Str: s}
 }
 
 var pkg = &internal.Package{


### PR DESCRIPTION
We want to represent pattern expressions as Disjunctions.
Since having a disjunction of values then becomes much
more common, it makes sense to not require it to be a vertex.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: If453fd0d56f7def2606ba22f8e93a2f45407c1a6
