### PR TITLE
internal/core/adt: introduce ArcNotPresent

### DIFF
--- a/cue/testdata/cycle/compbottom2.txtar
+++ b/cue/testdata/cycle/compbottom2.txtar
@@ -314,7 +314,7 @@ Disjuncts:    205
         foo: (string){ "" }
       }
       a: (struct){
-        bar: (_|_){
+        bar*: (_|_){
           // [cycle] mutual.mutualCycleFail.a: cycle with field b.foo:
           //     ./mutual.cue:9:10
         }

--- a/cue/testdata/cycle/compbottomnofinal.txtar
+++ b/cue/testdata/cycle/compbottomnofinal.txtar
@@ -375,7 +375,7 @@ Disjuncts:    230
       port: (string){ "" }
     }
     b: (struct){
-      port: (_|_){
+      port*: (_|_){
         // [cycle] minimal.b: cycle with field a.port:
         //     ./in.cue:18:6
       }
@@ -518,7 +518,7 @@ Disjuncts:    230
       Y: (struct){
         userinfo: (string){ "user" }
         host: (string){ "mod.test" }
-        port: (_|_){
+        port*: (_|_){
           // [cycle] large.p2.Y: undefined field: port:
           //     ./in.cue:267:10
         }
@@ -544,7 +544,7 @@ Disjuncts:    230
       Y: (struct){
         userinfo: (string){ "user" }
         host: (string){ "mod.test" }
-        port: (_|_){
+        port*: (_|_){
           // [cycle] large.p3.Y: undefined field: port:
           //     ./in.cue:308:10
         }
@@ -570,7 +570,7 @@ Disjuncts:    230
       Y: (struct){
         userinfo: (string){ "user" }
         host: (string){ "mod.test" }
-        port: (_|_){
+        port*: (_|_){
           // [cycle] large.p4.Y: undefined field: port:
           //     ./in.cue:351:10
         }

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -182,7 +182,7 @@ func (n *nodeContext) insertComprehension(
 				}
 
 				conjunct := MakeConjunct(env, c, ci)
-				n.node.state.insertFieldUnchecked(f.Label, ArcVoid, conjunct)
+				n.node.state.insertFieldUnchecked(f.Label, ArcPending, conjunct)
 				fields = append(fields, f)
 				// TODO: adjust ci to embed?
 
@@ -203,7 +203,7 @@ func (n *nodeContext) insertComprehension(
 				}
 
 				conjunct := MakeConjunct(env, c, ci)
-				n.node.state.insertFieldUnchecked(f.Label, ArcVoid, conjunct)
+				n.node.state.insertFieldUnchecked(f.Label, ArcPending, conjunct)
 				fields = append(fields, f)
 
 			default:

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -78,9 +78,9 @@ func (c *OpContext) evaluate(v *Vertex, r Resolver, state vertexStatus) Value {
 		// Use node itself to allow for cycle detection.
 		c.unify(v, state)
 
-		if v.ArcType == ArcVoid {
+		if v.ArcType == ArcPending {
 			if v.status == evaluating {
-				for ; v.Parent != nil && v.ArcType == ArcVoid; v = v.Parent {
+				for ; v.Parent != nil && v.ArcType == ArcPending; v = v.Parent {
 				}
 				err := c.Newf("cycle with field %v", r)
 				b := &Bottom{Code: CycleError, Err: err}
@@ -492,7 +492,7 @@ func (n *nodeContext) postDisjunct(state vertexStatus) {
 
 	switch err := n.getErr(); {
 	case err != nil:
-		if err.Code < IncompleteError && n.node.ArcType == ArcVoid {
+		if err.Code < IncompleteError && n.node.ArcType == ArcPending {
 			n.node.ArcType = ArcMember
 		}
 		n.node.BaseValue = err
@@ -754,7 +754,7 @@ func (n *nodeContext) completeArcs(state vertexStatus) {
 	if state <= conjuncts &&
 		// Is allowed to go one step back. See Vertex.UpdateStatus.
 		n.node.status <= state+1 &&
-		(!n.node.hasVoidArc || n.node.ArcType == ArcMember) {
+		(!n.node.hasPendingArc || n.node.ArcType == ArcMember) {
 
 		n.node.updateStatus(conjuncts)
 		return
@@ -772,11 +772,11 @@ func (n *nodeContext) completeArcs(state vertexStatus) {
 			// correctly and that we are not regressing.
 			n.node.updateStatus(evaluatingArcs)
 
-			wasVoid := a.ArcType == ArcVoid
+			wasVoid := a.ArcType == ArcPending
 
 			ctx.unify(a, finalized)
 
-			if a.ArcType == ArcVoid {
+			if a.ArcType == ArcPending {
 				continue
 			}
 
@@ -1744,7 +1744,7 @@ func (n *nodeContext) addValueConjunct(env *Environment, v Value, id CloseInfo) 
 		n.node.Structs = append(n.node.Structs, x.Structs...)
 
 		for _, a := range x.Arcs {
-			if a.ArcType == ArcVoid {
+			if !a.definitelyExists() {
 				continue
 			}
 			// TODO(errors): report error when this is a regular field.

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1882,7 +1882,7 @@ func (x *ForClause) yield(s *compState) {
 		}
 
 		c.unify(a, partial)
-		if a.ArcType == ArcVoid {
+		if !a.definitelyExists() {
 			continue
 		}
 
@@ -1894,6 +1894,7 @@ func (x *ForClause) yield(s *compState) {
 			// processing, eluding the deallocation step.
 			status:    finalized,
 			IsDynamic: true,
+			ArcType:   ArcMember,
 		}
 
 		if x.Value != InvalidLabel {
@@ -1901,6 +1902,7 @@ func (x *ForClause) yield(s *compState) {
 				Label:     x.Value,
 				BaseValue: a,
 				IsDynamic: true,
+				ArcType:   ArcPending,
 			}
 			n.Arcs = append(n.Arcs, b)
 		}

--- a/internal/core/debug/debug.go
+++ b/internal/core/debug/debug.go
@@ -220,6 +220,9 @@ func (w *printer) node(n adt.Node) {
 		}
 
 		for _, a := range x.Arcs {
+			if a.ArcType == adt.ArcNotPresent {
+				continue
+			}
 			if a.Label.IsLet() {
 				w.string("\n")
 				w.string("let ")

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -320,7 +320,7 @@ type conjuncts struct {
 func (c *conjuncts) getField(label adt.Feature) field {
 	f, ok := c.fields[label]
 	if !ok {
-		f.arcType = adt.ArcVoid
+		f.arcType = adt.ArcNotPresent
 	}
 	return f
 }
@@ -385,7 +385,7 @@ func (e *conjuncts) addExpr(env *adt.Environment, src *adt.Vertex, x adt.Elem, i
 
 		for _, d := range x.Decls {
 			var label adt.Feature
-			t := adt.ArcVoid
+			t := adt.ArcNotPresent
 			switch f := d.(type) {
 			case *adt.Field:
 				label = f.Label


### PR DESCRIPTION
ArcVoid's use is currently overloaded. The new
evaluator more strictly distinguishes between it.

ArcVoid is renamed to ArcPending, signifying that
it is still unknown which type the arc has and that
more work needs to be done to figure out. This
can be the case for comprehensions.

ArcNonExisting represents an arc that is known to
not exist. These may exist and linger after processing
as it is not always possible to remove an arc from
processing.

Signed-off-by: Marcel van Lohuizen <mpvl@gmail.com>
Change-Id: Ie090cae5e6bf5c664f863b1be491cb9ed4696d44
