### PR TITLE
internal/ci: top of stack commit for refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<!--
+
+TOP OF STACK COMMIT
+
+-->
 [![Go Reference](https://pkg.go.dev/badge/cuelang.org/go.svg)](https://pkg.go.dev/cuelang.org/go)
 [![Github](https://github.com/cue-lang/cue/actions/workflows/trybot.yml/badge.svg)](https://github.com/cue-lang/cue/actions/workflows/trybot.yml?query=branch%3Amaster+event%3Apush)
 [![GolangCI](https://golangci.com/badges/github.com/cue-lang/cue.svg)](https://golangci.com/r/github.com/cue-lang/cue)


### PR DESCRIPTION
This dummy commit acts as the top of stack commit for refactors of
internal/ci. It is the final commit prior to the refactors required for
the new cmd/cueckoo setup.

Having such a CL allows other repos to reference this change, but the
change also acts as a reference point for the refactors the other repos
need to make prior to the cmd/cueckoo refactor.

DO NOT REVIEW.
DO NOT SUBMIT.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I705fa101b972ac21ee2cfb03d4d6f73aad7c6bca
